### PR TITLE
fix boolean statements in calc_percs

### DIFF
--- a/workerEngineReduce.py
+++ b/workerEngineReduce.py
@@ -23,7 +23,7 @@ def calc_percs(white, black, draws):
 
     n = white + black + draws #wins + draws after move was played
 
-    if ((n > 0) and (config.DRAWSAREWINS)) == 0:
+    if (n > 0) and (config.DRAWSAREWINS == 0):
         total_games = n
         white_perc = white / n
         black_perc = black / n
@@ -31,7 +31,7 @@ def calc_percs(white, black, draws):
         return white_perc, black_perc, draw_perc, total_games
     
     else:
-        if ((n > 0) and (config.DRAWSAREWINS)) == 1:
+        if (n > 0) and (config.DRAWSAREWINS == 1):
                 total_games = n
                 white_perc = (white + draws) / n
                 black_perc = (black + draws) / n


### PR DESCRIPTION
`((n > 0) and (config.DRAWSAREWINS)) == 0` has the opposite of the intended behaviour because of misplaced parentheses. If n = 0 and config.DRAWSAREWINS is also 0, this whole statement evaluates to true (because `False and 0` evaluates to `False`, but `False == 0` evaluates to true). This leads to divide-by-zero errors.

This PR reinstates the intended behaviour.