### PR TITLE
Preserve explicit zero values for soundness/move-loss settings

### DIFF
--- a/client/src/algorithm/MoveSelector.js
+++ b/client/src/algorithm/MoveSelector.js
@@ -86,35 +86,35 @@ class MoveSelector {
         this.config = {
             // ENGINE VALIDATION SETTINGS
             // ---------------------------
-            CAREABOUTENGINE: config.CAREABOUTENGINE || 1,  // 1 = validate with engine, 0 = skip
+            CAREABOUTENGINE: config.CAREABOUTENGINE ?? 1,  // 1 = validate with engine, 0 = skip
 
             // Maximum allowed centipawn loss from best move
             // -99 means moves can be up to 99 centipawns worse than engine's best
             // Negative value is used because we compare: if (loss > Math.abs(SOUNDNESSLIMIT))
-            SOUNDNESSLIMIT: config.SOUNDNESSLIMIT || -99,
+            SOUNDNESSLIMIT: config.SOUNDNESSLIMIT ?? -99,
 
             // Secondary loss limit (for moves that aren't the engine's best)
-            LOSSLIMIT: config.LOSSLIMIT || -99,
+            LOSSLIMIT: config.LOSSLIMIT ?? -99,
 
             // Evaluation threshold where LOSSLIMIT is ignored
             // If position eval > 300 centipawns, we're winning so much that small losses don't matter
-            IGNORELOSSLIMIT: config.IGNORELOSSLIMIT || 300,
+            IGNORELOSSLIMIT: config.IGNORELOSSLIMIT ?? 300,
 
             // DATA QUALITY THRESHOLDS
             // -----------------------
             // Minimum play rate (as decimal, not percentage)
             // 0.001 = 0.1% of games at this position must play this move
-            MINPLAYRATE: config.MINPLAYRATE || 0.001,
+            MINPLAYRATE: config.MINPLAYRATE ?? 0.001,
 
             // Minimum number of games for statistical significance
             // With fewer games, win rate statistics are unreliable
-            MINGAMES: config.MINGAMES || 19,
+            MINGAMES: config.MINGAMES ?? 19,
 
             // STATISTICAL SELECTION SETTINGS
             // ------------------------------
             // Alpha for confidence interval (0.001 = 99.9% confidence)
             // Lower alpha = wider confidence interval = more conservative
-            ALPHA: config.ALPHA || 0.001,
+            ALPHA: config.ALPHA ?? 0.001,
 
             // Include all other config properties passed by user
             ...config

--- a/client/src/ui/FormController.js
+++ b/client/src/ui/FormController.js
@@ -954,8 +954,12 @@ class FormController {
             ENGINEVARIANT: formConfig['engine-full'] ? 'full' : 'lite',
             ENGINEDEPTH: parseInt(formConfig['engine-depth']) || 20,
             ENGINEFINISH: parseInt(formConfig['engine-finishing']) || 1,
-            SOUNDNESSLIMIT: parseInt(formConfig['soundness-limit-centipawns']) || -99,
-            MOVELOSSLIMIT: parseInt(formConfig['move-loss-limit-centipawns']) || -99,
+            SOUNDNESSLIMIT: Number.isNaN(parseInt(formConfig['soundness-limit-centipawns'], 10))
+                ? -99
+                : parseInt(formConfig['soundness-limit-centipawns'], 10),
+            MOVELOSSLIMIT: Number.isNaN(parseInt(formConfig['move-loss-limit-centipawns'], 10))
+                ? -99
+                : parseInt(formConfig['move-loss-limit-centipawns'], 10),
             IGNORELOSSLIMIT: parseInt(formConfig['ignore-loss-limit']) || 300,
             ENGINEHASH: parseInt(formConfig['engine-hash']) || 320,
 

--- a/client/tests/soundness-limit-config-regression.test.js
+++ b/client/tests/soundness-limit-config-regression.test.js
@@ -1,0 +1,55 @@
+import MoveSelector from '../src/algorithm/MoveSelector.js';
+import FormController from '../src/ui/FormController.js';
+import PgnProcessor from '../src/utils/PgnProcessor.js';
+
+describe('Soundness/Move-loss config wiring regressions', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('MoveSelector preserves explicit zero limits', () => {
+        const selector = new MoveSelector({
+            CAREABOUTENGINE: 0,
+            SOUNDNESSLIMIT: 0,
+            LOSSLIMIT: 0
+        });
+
+        expect(selector.config.CAREABOUTENGINE).toBe(0);
+        expect(selector.config.SOUNDNESSLIMIT).toBe(0);
+        expect(selector.config.LOSSLIMIT).toBe(0);
+    });
+
+    test('FormController maps form ids to SOUNDNESSLIMIT/LOSSLIMIT and preserves 0', async () => {
+        jest.spyOn(PgnProcessor, 'processPgn').mockResolvedValue({
+            name: 'King Pawn Opening',
+            moves: ['e4'],
+            moveCount: 1,
+            priority: 1
+        });
+
+        const controller = Object.create(FormController.prototype);
+        controller.getSelectedSpeeds = jest.fn().mockReturnValue(['blitz']);
+        controller.getSelectedRatings = jest.fn().mockReturnValue(['1800']);
+        controller.convertGamesProbability = jest.fn().mockReturnValue(0.02);
+        controller.convertPercentage = jest.fn().mockReturnValue(0.01);
+        controller.convertConfidence = jest.fn().mockReturnValue(0.05);
+
+        const config = await controller.convertToBookBuilderConfig({
+            'pgn-input-text': '1. e4',
+            'output-format': 'individual',
+            'annotation-style': 'endBlock',
+            'draws-half-point': true,
+            'engine-enabled': true,
+            'engine-full': false,
+            'engine-depth': 20,
+            'engine-finishing': 1,
+            'soundness-limit': 0,
+            'move-loss-limit': 0,
+            'ignore-loss-limit': 300,
+            'engine-hash': 320
+        });
+
+        expect(config.SOUNDNESSLIMIT).toBe(0);
+        expect(config.LOSSLIMIT).toBe(0);
+    });
+});


### PR DESCRIPTION
### Motivation

- Users setting strict thresholds like `SOUNDNESSLIMIT = 0` or `MOVELOSSLIMIT = 0` were having those values silently overwritten by falsy fallbacks, causing the algorithm to ignore explicit zero settings. 
- The form parsing also used `||` which converted a parsed `0` into the default `-99`, making strict soundness settings ineffective.

### Description

- Switched default merging in `MoveSelector` from `||` to nullish coalescing (`??`) so explicit `0` (and other intentional falsy numeric values) are preserved for `CAREABOUTENGINE`, `SOUNDNESSLIMIT`, `LOSSLIMIT`, `IGNORELOSSLIMIT`, `MINPLAYRATE`, `MINGAMES`, and `ALPHA` (`client/src/algorithm/MoveSelector.js`).
- Updated form parsing logic to only default when parsing actually fails by using `Number.isNaN(parseInt(..., 10)) ? -99 : parseInt(...)` for `SOUNDNESSLIMIT` and `MOVELOSSLIMIT` so an entered `0` remains `0` (`client/src/ui/FormController.js`).
- Kept previous default semantics for unset/invalid values and preserved spread of `...config` so user-provided keys still override defaults.

### Testing

- Ran the quick automated smoke check by instantiating `MoveSelector` with zeros using:
  `node -e "import('./client/src/algorithm/MoveSelector.js').then(({default:M})=>{const a=new M({SOUNDNESSLIMIT:0,LOSSLIMIT:0,CAREABOUTENGINE:0}); console.log(a.config.SOUNDNESSLIMIT,a.config.LOSSLIMIT,a.config.CAREABOUTENGINE);})"` and verified output `0 0 0`, confirming explicit zeros are preserved.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0137d267a883339c41f905875d30ab)