### PR TITLE
Preserve explicit zero for soundness/move-loss config and robust form parsing

### DIFF
--- a/client/src/algorithm/MoveSelector.js
+++ b/client/src/algorithm/MoveSelector.js
@@ -86,35 +86,35 @@ class MoveSelector {
         this.config = {
             // ENGINE VALIDATION SETTINGS
             // ---------------------------
-            CAREABOUTENGINE: config.CAREABOUTENGINE || 1,  // 1 = validate with engine, 0 = skip
+            CAREABOUTENGINE: config.CAREABOUTENGINE ?? 1,  // 1 = validate with engine, 0 = skip
 
             // Maximum allowed centipawn loss from best move
             // -99 means moves can be up to 99 centipawns worse than engine's best
             // Negative value is used because we compare: if (loss > Math.abs(SOUNDNESSLIMIT))
-            SOUNDNESSLIMIT: config.SOUNDNESSLIMIT || -99,
+            SOUNDNESSLIMIT: config.SOUNDNESSLIMIT ?? -99,
 
             // Secondary loss limit (for moves that aren't the engine's best)
-            LOSSLIMIT: config.LOSSLIMIT || -99,
+            LOSSLIMIT: config.LOSSLIMIT ?? -99,
 
             // Evaluation threshold where LOSSLIMIT is ignored
             // If position eval > 300 centipawns, we're winning so much that small losses don't matter
-            IGNORELOSSLIMIT: config.IGNORELOSSLIMIT || 300,
+            IGNORELOSSLIMIT: config.IGNORELOSSLIMIT ?? 300,
 
             // DATA QUALITY THRESHOLDS
             // -----------------------
             // Minimum play rate (as decimal, not percentage)
             // 0.001 = 0.1% of games at this position must play this move
-            MINPLAYRATE: config.MINPLAYRATE || 0.001,
+            MINPLAYRATE: config.MINPLAYRATE ?? 0.001,
 
             // Minimum number of games for statistical significance
             // With fewer games, win rate statistics are unreliable
-            MINGAMES: config.MINGAMES || 19,
+            MINGAMES: config.MINGAMES ?? 19,
 
             // STATISTICAL SELECTION SETTINGS
             // ------------------------------
             // Alpha for confidence interval (0.001 = 99.9% confidence)
             // Lower alpha = wider confidence interval = more conservative
-            ALPHA: config.ALPHA || 0.001,
+            ALPHA: config.ALPHA ?? 0.001,
 
             // Include all other config properties passed by user
             ...config

--- a/client/src/ui/FormController.js
+++ b/client/src/ui/FormController.js
@@ -954,8 +954,12 @@ class FormController {
             ENGINEVARIANT: formConfig['engine-full'] ? 'full' : 'lite',
             ENGINEDEPTH: parseInt(formConfig['engine-depth']) || 20,
             ENGINEFINISH: parseInt(formConfig['engine-finishing']) || 1,
-            SOUNDNESSLIMIT: parseInt(formConfig['soundness-limit-centipawns']) || -99,
-            MOVELOSSLIMIT: parseInt(formConfig['move-loss-limit-centipawns']) || -99,
+            SOUNDNESSLIMIT: Number.isNaN(parseInt(formConfig['soundness-limit'], 10))
+                ? -99
+                : parseInt(formConfig['soundness-limit'], 10),
+            LOSSLIMIT: Number.isNaN(parseInt(formConfig['move-loss-limit'], 10))
+                ? -99
+                : parseInt(formConfig['move-loss-limit'], 10),
             IGNORELOSSLIMIT: parseInt(formConfig['ignore-loss-limit']) || 300,
             ENGINEHASH: parseInt(formConfig['engine-hash']) || 320,
 

--- a/client/tests/soundness-limit-config-regression.test.js
+++ b/client/tests/soundness-limit-config-regression.test.js
@@ -1,0 +1,55 @@
+import MoveSelector from '../src/algorithm/MoveSelector.js';
+import FormController from '../src/ui/FormController.js';
+import PgnProcessor from '../src/utils/PgnProcessor.js';
+
+describe('Soundness/Move-loss config wiring regressions', () => {
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('MoveSelector preserves explicit zero limits', () => {
+        const selector = new MoveSelector({
+            CAREABOUTENGINE: 0,
+            SOUNDNESSLIMIT: 0,
+            LOSSLIMIT: 0
+        });
+
+        expect(selector.config.CAREABOUTENGINE).toBe(0);
+        expect(selector.config.SOUNDNESSLIMIT).toBe(0);
+        expect(selector.config.LOSSLIMIT).toBe(0);
+    });
+
+    test('FormController maps form ids to SOUNDNESSLIMIT/LOSSLIMIT and preserves 0', async () => {
+        jest.spyOn(PgnProcessor, 'processPgn').mockResolvedValue({
+            name: 'King Pawn Opening',
+            moves: ['e4'],
+            moveCount: 1,
+            priority: 1
+        });
+
+        const controller = Object.create(FormController.prototype);
+        controller.getSelectedSpeeds = jest.fn().mockReturnValue(['blitz']);
+        controller.getSelectedRatings = jest.fn().mockReturnValue(['1800']);
+        controller.convertGamesProbability = jest.fn().mockReturnValue(0.02);
+        controller.convertPercentage = jest.fn().mockReturnValue(0.01);
+        controller.convertConfidence = jest.fn().mockReturnValue(0.05);
+
+        const config = await controller.convertToBookBuilderConfig({
+            'pgn-input-text': '1. e4',
+            'output-format': 'individual',
+            'annotation-style': 'endBlock',
+            'draws-half-point': true,
+            'engine-enabled': true,
+            'engine-full': false,
+            'engine-depth': 20,
+            'engine-finishing': 1,
+            'soundness-limit': 0,
+            'move-loss-limit': 0,
+            'ignore-loss-limit': 300,
+            'engine-hash': 320
+        });
+
+        expect(config.SOUNDNESSLIMIT).toBe(0);
+        expect(config.LOSSLIMIT).toBe(0);
+    });
+});


### PR DESCRIPTION
### Motivation

- Fix a regression where explicit zero values for soundness/move-loss were treated as falsy and replaced by defaults, causing incorrect engine filtering.
- Make form input parsing more robust so that a user-entered `0` is preserved rather than coerced to the fallback.
- Add a regression test to lock in the intended behavior that zeros are valid configuration values.

### Description

- Replace falsy fallbacks with nullish coalescing (`??`) in `MoveSelector` defaults so `0` and other valid falsy values are preserved in `this.config`.
- Update `FormController` parsing for soundness and move-loss fields to use `Number.isNaN(parseInt(..., 10)) ? <default> : parseInt(...)` and align the field keys to `soundness-limit` and `move-loss-limit`, ensuring `0` is not lost.
- Ensure the `LOSSLIMIT` config key is set from the form mapping and included in the merged `config` passed to `MoveSelector`.
- Add `client/tests/soundness-limit-config-regression.test.js` to assert that both `MoveSelector` and `FormController` preserve explicitly set zero limits.

### Testing

- Ran the Jest unit test suite including the new `soundness-limit-config-regression.test.js` regression test, and the tests passed.
- Verified the new test covers `MoveSelector` construction with zeros and `FormController.convertToBookBuilderConfig` mapping and both assertions succeeded.
- Ran existing CI unit tests locally to ensure no other regressions were introduced and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0137d267a883339c41f905875d30ab)