### PR TITLE
fix(engine): restore Python soundness/move-loss semantics

### DIFF
--- a/PLAN-soundness-semantics-fix.md
+++ b/PLAN-soundness-semantics-fix.md
@@ -1,124 +1,103 @@
 # Plan: Restore Python soundness/move-loss semantics in the JS port
 
-This plan addresses a semantic regression introduced during the Python-to-JS
-port of BookBuilder's move selection algorithm. The user-facing **Soundness
-Limit** and **Move Loss Limit** controls behave differently in the JS code
-than in the Python original and than the HTML help text describes.
+## Context
 
-See also: PR #30, #31, #32 (Codex), which address related wiring bugs but
-not the semantic regression covered here.
+`PLAN-soundness-semantics-fix.md` (committed in #33) lays out the fix for a
+semantic regression introduced during the Python→JS port of BookBuilder's
+move-selection algorithm. The user-facing **Soundness Limit** and **Move Loss
+Limit** controls behave differently in the JS code than in the Python original
+(`origin/pythonlegacy:workerEngineReduce.py:268`) and than the HTML help text
+describes. Per the user's request, I asked Codex to review that plan against
+the live code. This file folds Codex's findings into a revised plan ready to
+execute. Goal: ship the fix in one PR off updated `web`, with failing tests
+written first.
 
----
-
-## Background — what the controls are supposed to mean
-
-From `client/app.html:2103,2110` and the Python original
-(`workerEngineReduce.py:268` on the `pythonlegacy` branch):
-
-- **Soundness Limit** — absolute eval floor on the position *after* our move,
-  in our perspective. "Never accept a position worse than this." Compared
-  against `afterOurMoveScore` (signed, our POV).
-- **Move Loss Limit** — relative drop vs. the engine's best move. "Tolerate
-  losing up to this many centipawns vs. engine best." Compared against
-  signed `moveLoss = afterOurMoveScore − bestEval` (negative = worse).
-- **Ignore Loss Limit** — eval threshold above which both gates relax.
-  "If we're winning by more than this, accept the move regardless."
-
-Python condition (`workerEngineReduce.py:268`):
-
-```python
-if ( (afterOurMoveScore > soundness_limit) and (moveLoss > move_loss_limit) )
-   or (afterOurMoveScore > ignore_loss_limit)
-   or (moveLoss >= 0):
-    # approve
-```
-
-Two orthogonal gates; two escapes.
+Codex flagged four substantive issues with the original plan. Each is
+addressed below.
 
 ---
 
-## What the JS port actually does
+## Codex review findings (incorporated)
 
-`client/src/algorithm/MoveSelector.js:971-1008` (lazy path; legacy at
-`:501-554` is identical):
+1. **No real "engine-best eval-floor pre-check" exists in Python.** The
+   block at `origin/pythonlegacy:workerEngineReduce.py:205-212` only logs;
+   every effect is commented out, and `:160-165` approves the top engine move
+   immediately. The original plan's table overstated this. **Action:** drop
+   the "engine-best eval-floor pre-check" row from the diff table; do not add
+   such a check in the JS port.
 
-```js
-const centipawnLoss = analysis?.moveLoss || 0;
-if (centipawnLoss > Math.abs(this.config.SOUNDNESSLIMIT)) return false;
-if (centipawnLoss > Math.abs(this.config.LOSSLIMIT)) {
-    const absoluteEval = Math.abs(analysis?.evaluation || 0);
-    if (absoluteEval < this.config.IGNORELOSSLIMIT) return false;
-}
-return true;
-```
+2. **`?? 0` defaults silently approve stale analysis objects** because
+   `signedMoveLoss >= 0` then passes. Existing mocks return only
+   `moveLoss`/`evaluation` (e.g. `client/tests/lazy-engine-comparison.test.js:109-116`,
+   `client/tests/move-selector.test.js:450-502`,
+   `client/tests/perspective-invariants.test.js:372-405`). **Action:** fail
+   closed when the new fields are missing, and update every mock/test in the
+   same PR. See Step 2a + Step 5 below.
 
-Differences from Python:
+3. **Mate handling tests must match engine scale.** Real engines produce
+   `±10000` for mate scores (`StockfishEngine.js:377-380`,
+   `NodeStockfishEngine.js:293-297`), but `MATE_SCORE_THRESHOLD = 999999`
+   (`MoveSelector.js:61-65`), so `_handleMateScenarios` is effectively dead
+   for real engine output. **Action:** use `±10000` in mate tests, not
+   `±9999999`; document that dropping `_handleMateScenarios` is safe because
+   it is already unreachable for real engine output (only the Python parity
+   path matters).
 
-| Concern | Python | JS port | Effect |
-|---|---|---|---|
-| Soundness Limit quantity checked | `afterOurMoveScore` (absolute) | `analysis.moveLoss` (relative) | Soundness is no longer an eval floor; just a stricter Move Loss Limit |
-| Sign handling | Signed `>` comparison | `Math.abs(SOUNDNESSLIMIT)` etc. | User's typed sign is discarded; `+50` and `-50` behave identically |
-| `moveLoss` sign | Signed; negative = worse | `Math.abs(moveLoss)`; positive magnitude | Loses information |
-| `ignore_loss_limit` trigger | `afterOurMoveScore > ignore_loss_limit` | `Math.abs(evaluation) < IGNORELOSSLIMIT` | Fires symmetrically in deeply losing positions (wrong) |
-| `moveLoss >= 0` escape | Explicit OR clause | Only `move === engineBestMove` fast path | Loses the "engine actually prefers our move on deeper analysis" case |
-| Engine-best eval-floor pre-check | Present (`:205`) | Absent | Engine best move never validated against the floor |
-| Two limits redundant? | No, orthogonal | Yes — both gate the same `centipawnLoss` | Soundness Limit slider is redundant |
+4. **Mate-against-us description was imprecise.** Python `:268` accepts a
+   mate-against-us when the engine best is also mating against us
+   (`moveLoss >= 0` clause). **Action:** clarify the comment in the new
+   `_passesSoundnessCheck` so future readers know the `signedMoveLoss >= 0`
+   escape covers this.
 
-Additionally, `analysis.afterEval` and `analysis.evaluation` are returned by
-the engine wrappers from the **opponent's** perspective despite their names
-(`client/src/engine/StockfishEngine.js:521-538` — only the local
-`adjustedAfterEval` variable is in our POV, and it isn't exported). Any fix
-that compares against an "after eval" must first expose a perspective-correct
-field.
-
----
-
-## Prerequisites & branch strategy
-
-- **Wait for Codex PR #31 or #32 to merge into `web`.** They fix the form-key
-  wiring that this work depends on (form ID `soundness-limit` →
-  `formConfig['soundness-limit']`, and `MOVELOSSLIMIT` →`LOSSLIMIT` on the
-  output object).
-- Close the duplicate of #31/#32 and close **#30** (its added test
-  contradicts its own code changes).
-- Branch this work off the updated `web` as
-  `claude/soundness-semantics-fix`. All changes go in one PR.
-- Write failing tests **first** (Step 5), then make them pass.
+Minor accuracy fixups Codex caught:
+- `NodeStockfishEngine.js:527-540` → actual block is `:526-539`.
+- Always cite `origin/pythonlegacy:workerEngineReduce.py:268` (fully
+  qualified) rather than bare `pythonlegacy:...`.
 
 ---
 
-## Step 1 — Normalize "after eval" perspective in the engine wrappers
+## Prerequisites
+
+- Wait for Codex PR #31/#32 to merge into `web` (form-key wiring fixes).
+- Close duplicate of #31/#32 and close #30 (its test contradicts its code).
+- Branch off updated `web` as `claude/soundness-semantics-fix`.
+- Write failing tests first (Step 5), then make them pass.
+
+---
+
+## Step 1 — Add perspective-correct fields in engine wrappers
 
 **Files:**
-- `client/src/engine/StockfishEngine.js`
-- `client/src/engine/NodeStockfishEngine.js`
-- `client/src/engine/MockStockfishEngine.js`
+- `client/src/engine/StockfishEngine.js` (block at `:521-538`)
+- `client/src/engine/NodeStockfishEngine.js` (block at `:526-539`)
+- `client/src/engine/MockStockfishEngine.js` (`:216-225`)
 
-In `StockfishEngine.js:521-538` (and mirror at `NodeStockfishEngine.js:527-540`):
+Add two new fields to the returned analysis object — do **not** rename
+`evaluation` / `afterEval` (consumed by `_handleMateScenarios` and various
+UI/quality paths; flipping sign would invert mate detection):
 
 ```js
-const adjustedAfterEval = -afterEval;                  // our perspective
-const signedMoveLoss = adjustedAfterEval - beforeEval; // negative = our move worse than best
+const adjustedAfterEval = -afterEval;                  // our POV
+const signedMoveLoss = adjustedAfterEval - beforeEval; // negative = worse
 const moveLoss = beforeEval - adjustedAfterEval;       // legacy magnitude
 const absMoveLoss = Math.abs(moveLoss);
 const quality = this.calculateMoveQuality(absMoveLoss);
 
 return {
     evaluation: afterEval,            // unchanged — raw, opponent POV
-    moveLoss: absMoveLoss,            // unchanged — magnitude (used by quality UI)
+    moveLoss: absMoveLoss,            // unchanged — magnitude (quality UI)
     quality,
     beforeEval,                       // unchanged — our POV
     afterEval,                        // unchanged — raw, opponent POV
     afterEvalOurs: adjustedAfterEval, // NEW — our POV, signed
-    signedMoveLoss                    // NEW — our POV, signed (negative = worse)
+    signedMoveLoss                    // NEW — our POV, signed (neg = worse)
 };
 ```
 
-Mirror in `MockStockfishEngine.js` (around line 216-225).
+Mirror in `MockStockfishEngine.js`.
 
-**Rationale:** add fields rather than rename. `analysis.evaluation` is
-consumed by `_handleMateScenarios` (`MoveSelector.js:613-634`); flipping its
-sign would invert mate detection. Adding new fields is non-breaking.
+Document on the return-object JSDoc that `evaluation`/`afterEval` are
+**opponent POV** while `afterEvalOurs`/`signedMoveLoss` are **our POV**.
 
 ---
 
@@ -132,15 +111,26 @@ sign would invert mate detection. Adding new fields is non-breaking.
 _passesSoundnessCheck(moveUci, engineBestMove, analysis) {
     if (moveUci === engineBestMove) return true;
 
-    const afterEval = analysis?.afterEvalOurs ?? 0;
-    const signedMoveLoss = analysis?.signedMoveLoss ?? 0;
-
     this._validateMoveAnalysis(analysis, `_passesSoundnessCheck(${moveUci})`);
 
-    // Mirror Python workerEngineReduce.py:268 — three OR branches:
-    //   1. Both individual gates pass
+    // Fail closed: required fields must be present and finite.
+    // (Per Codex review: defaulting to 0 silently approves stale objects
+    // via the signedMoveLoss >= 0 escape.)
+    const afterEval = analysis?.afterEvalOurs;
+    const signedMoveLoss = analysis?.signedMoveLoss;
+    if (!Number.isFinite(afterEval) || !Number.isFinite(signedMoveLoss)) {
+        log.warn(
+            `_passesSoundnessCheck(${moveUci}): missing afterEvalOurs/signedMoveLoss; rejecting`
+        );
+        return false;
+    }
+
+    // Mirror origin/pythonlegacy:workerEngineReduce.py:268 — three OR branches:
+    //   1. Both individual gates pass (eval floor AND relative drop)
     //   2. Position is winning enough that we relax both gates
-    //   3. Our move is at least as good as engine's best
+    //   3. signedMoveLoss >= 0: our move is at least as good as engine best.
+    //      Also covers the "mate-against-us when engine best is equally mating
+    //      against us" case (both eval to -mate, so signedMoveLoss == 0).
     if (afterEval > this.config.IGNORELOSSLIMIT) return true;
     if (signedMoveLoss >= 0) return true;
 
@@ -158,157 +148,164 @@ validateMoveSoundness(fen, move, engineBestMove, moveAnalysis) {
 }
 ```
 
-### 2c. Remove every `Math.abs(this.config.SOUNDNESSLIMIT)` and `Math.abs(this.config.LOSSLIMIT)`
+### 2c. Remove every `Math.abs(this.config.SOUNDNESSLIMIT|LOSSLIMIT)`
 
-After this step:
-
+Verify with:
 ```bash
 git grep -n "Math.abs(this.config.SOUNDNESSLIMIT\|Math.abs(this.config.LOSSLIMIT)"
 ```
-
-should return zero hits.
+Must return zero hits.
 
 ### 2d. Drop `_handleMateScenarios` (lines 613-634)
 
-With signed `afterEvalOurs`, mate-for-us produces a large positive value that
-naturally clears every gate, and mate-against-us produces a large negative
-value that naturally fails soundness. The Python original has no equivalent of
-the "avoidable mate" branch — drop it for parity.
+Per Codex: with `MATE_SCORE_THRESHOLD = 999999` and engine mate values of
+`±10000`, this branch is already unreachable for real engine output. With
+signed `afterEvalOurs`, mate-for-us produces a large positive value (clears
+every gate) and avoidable mate-against-us fails soundness naturally. Equal
+mate-against-us is approved via the `signedMoveLoss >= 0` escape, matching
+Python `:268`. Drop the function and its call sites for parity and dead-code
+removal.
 
 ---
 
-## Step 3 — Update comments, JSDoc, and inline docs
+## Step 3 — Update comments / JSDoc
 
 **File:** `client/src/algorithm/MoveSelector.js`.
 
-- Lines **28-33** (header "KEY CONCEPTS") — rewrite Soundness Limit and Move
+- Lines **28-33** (header "KEY CONCEPTS"): rewrite Soundness Limit / Move
   Loss Limit definitions to match HTML help text and Python semantics.
-- Lines **76-78** (constructor param JSDoc) — `SOUNDNESSLIMIT` is "absolute
-  eval floor (our perspective, centipawns)"; `LOSSLIMIT` is "max centipawn
-  drop vs. engine best (signed, negative = looser)".
-- Lines **91-93** (inline comment) — same.
-- Lines **957-968** (`_passesSoundnessCheck` JSDoc) — describe both gates and
-  both escapes explicitly. Reference `workerEngineReduce.py:268` so future
-  readers can verify against the Python original.
+- Lines **76-78** (constructor JSDoc): `SOUNDNESSLIMIT` = "absolute eval
+  floor (our POV, centipawns)"; `LOSSLIMIT` = "max signed drop vs. engine
+  best (negative = looser)".
+- Lines **91-93** (inline comment): same.
+- Lines **957-968** (`_passesSoundnessCheck` JSDoc): describe both gates +
+  both escapes; cite `origin/pythonlegacy:workerEngineReduce.py:268`.
 
 ---
 
 ## Step 4 — Audit preset values in `sample-openings.js`
 
-**File:** `client/src/config/sample-openings.js`.
+**File:** `client/src/config/sample-openings.js` (`:115,119,158,189`).
 
-Presets at `:115,119,158,189` were tuned under broken semantics where
-SOUNDNESSLIMIT was effectively another move-loss cap. With the fix the
-numbers mean different things (eval floor vs. relative drop). Re-pick per
-preset intent:
+Numbers were tuned under broken semantics. Re-pick:
+- "Relaxed": `soundnessLimit: -300, moveLossLimit: -100`.
+- "Strict": `soundnessLimit: -50, moveLossLimit: -30`.
 
-- "Relaxed" preset: `soundnessLimit: -300, moveLossLimit: -100`.
-- "Strict" preset: `soundnessLimit: -50, moveLossLimit: -30`.
-
-Cosmetic, not behavioral; keep minimal and call out in the PR description.
+Cosmetic; call out in PR description.
 
 ---
 
-## Step 5 — Tests (write these BEFORE Step 1-2 so they fail first)
+## Step 5 — Tests (write BEFORE Step 1-2)
 
 ### `client/tests/move-selector-semantics.test.js` (new)
 
-Table-driven cases against `_passesSoundnessCheck` with synthetic `analysis`
-objects:
+Table-driven cases against `_passesSoundnessCheck`. **Use ±10000 not
+±9999999** for mate cases (matches engine output per Codex):
 
 ```js
 const cases = [
-    // [name, afterEvalOurs, signedMoveLoss, SOUND, LOSS, IGNORE, expectApprove]
+    // [name, afterEvalOurs, signedMoveLoss, SOUND, LOSS, IGNORE, expect]
     ['within both limits',           -50,  -70,  -99,  -99, 300, true ],
     ['eval-floor violation',        -150, -170,  -99,  -99, 300, false], // smoking gun
     ['strict floor, lax move-loss',  -80,  -50,  -50,  -99, 300, false],
     ['move-loss violation',         -150, -200,  -99, -100, 300, false],
     ['IGNORELOSSLIMIT escape',      +400, +380,  -99,  -99, 300, true ],
     ['both gates fail',             -200, -220,  -99,  -99, 300, false],
-    ['engine likes our move',       +50,   +30,  -99,  -99, 300, true ],
-    ['mate for us',            +9999999, +999,  -99,  -99, 300, true ],
-    ['mate against us',        -9999999, -999,  -99,  -99, 300, false],
-    ['positive floor accepts',      +80,   +30, +50,  -99, 300, true ],
-    ['positive floor rejects',      +30,   -20, +50,  -99, 300, false],
+    ['engine likes our move',        +50,  +30,  -99,  -99, 300, true ],
+    ['mate for us',               +10000, +999,  -99,  -99, 300, true ],
+    ['avoidable mate against us', -10000,-9000,  -99,  -99, 300, false],
+    ['equal mate against us',     -10000,    0,  -99,  -99, 300, true ], // Python parity
+    ['positive floor accepts',       +80,  +30,  +50,  -99, 300, true ],
+    ['positive floor rejects',       +30,  -20,  +50,  -99, 300, false],
+    ['missing fields → reject',     undefined, undefined, -99, -99, 300, false], // fail-closed
 ];
 ```
 
-Run the table against both the lazy-path entry and the legacy-batch-path
-entry. Row 2 and row 10 are the regressions; row 11 catches the `Math.abs`
-sign-inversion bug.
+Run against both lazy-path and legacy-batch-path entries. Rows 2/11 are the
+core regressions; row 12 catches the `Math.abs` sign-inversion bug; row 13
+covers the Codex fail-closed fix.
 
 ### `client/tests/engine-perspective-contract.test.js` (new)
 
-One test using `MockStockfishEngine` (or real Stockfish gated behind
+Using `MockStockfishEngine` (or real Stockfish gated behind
 `RUN_ENGINE_TESTS=1`): on a known white-blunders position, assert
 `analysis.afterEvalOurs < 0` and `analysis.signedMoveLoss < 0`. Pins the
 perspective convention.
 
 ### `client/tests/python-parity.test.js` (new, optional but cheap)
 
-Encode the Python expression verbatim as a JS reference function.
-Property-test 1000 seeded random tuples; assert agreement with
-`_passesSoundnessCheck`. Catches any future semantic drift.
+Encode Python `:268` verbatim as a JS reference function. Property-test 1000
+seeded random tuples; assert agreement with `_passesSoundnessCheck`.
 
 ### `client/tests/danish-gambit-regression.test.js` (new)
 
-End-to-end with `MockStockfishEngine`. Mock the lichess client to return
-candidates `[Nf3, d4, Bc4]` after `1.e4 e5`; mock engine evals so d4 produces
+End-to-end with `MockStockfishEngine`. Mock lichess client to return
+`[Nf3, d4, Bc4]` after `1.e4 e5`; mock engine evals so d4 produces
 `signedMoveLoss ≈ -25`. Assert:
+- `LOSSLIMIT = -10`: selected move is `Nf3` (d4 rejected).
+- `LOSSLIMIT = -50`: selected move can be `d4`.
 
-- With `LOSSLIMIT = -10`: selected move is `Nf3` (d4 rejected).
-- With `LOSSLIMIT = -50`: selected move can be `d4`.
+### Update existing mocks/tests in same PR
 
-This test demonstrably reproduces and fixes the original report.
+These return only `moveLoss`/`evaluation` and will fail-closed after Step
+2a unless updated to include `afterEvalOurs`/`signedMoveLoss`:
+- `client/tests/lazy-engine-comparison.test.js:109-116`
+- `client/tests/move-selector.test.js:450-502`
+- `client/tests/perspective-invariants.test.js:372-405`
 
 ### Keep
-
-The form-wiring regression test added in Codex PR #31/#32
+Form-wiring regression test from #31/#32
 (`soundness-limit-config-regression.test.js`).
 
 ---
 
 ## Step 6 — UX/copy follow-up
 
-After the semantic fix, **Soundness Limit alone won't address the original
-poster's "avoid Danish" goal** — d4 doesn't leave white in a worse position,
-so no eval floor short of +0.30 would reject it, and a +30 floor would also
-reject most reasonable openings. The right knob is **Move Loss Limit ≈ -10 to
--20**.
-
-Update `client/app.html:2103,2110` help text:
-
-- **Soundness Limit** — keep current wording; add "useful for avoiding
-  objectively losing positions, not for choosing between two playable lines."
+`client/app.html:2103,2110`:
+- **Soundness Limit** — keep wording; add "useful for avoiding objectively
+  losing positions, not for choosing between two playable lines."
 - **Move Loss Limit** — emphasize "this is the knob to make the algorithm
   prefer engine-best moves. Try -20 if you want to closely follow engine
   recommendations."
 
 ---
 
-## Verification checklist
+## Critical files modified
 
-- [ ] All four pre-existing bugs (form key typo, MOVELOSSLIMIT vs LOSSLIMIT,
-      `||` falsy-zero, `Math.abs` sign-inversion) have explicit regression
-      tests.
-- [ ] `git grep -n "Math.abs(this.config.SOUNDNESSLIMIT\|Math.abs(this.config.LOSSLIMIT)"`
-      returns nothing.
-- [ ] `git grep -n "centipawnLoss > Math.abs"` returns nothing.
-- [ ] `npm test` passes locally including new test files.
-- [ ] Manually reproduce the user's scenario in the browser: load with
-      `Move Loss Limit = -20`, generate from `1. e4` PGN, confirm Nf3 is
-      chosen.
+- `client/src/engine/StockfishEngine.js`
+- `client/src/engine/NodeStockfishEngine.js`
+- `client/src/engine/MockStockfishEngine.js`
+- `client/src/algorithm/MoveSelector.js`
+- `client/src/config/sample-openings.js`
+- `client/app.html`
+- `client/tests/move-selector-semantics.test.js` (new)
+- `client/tests/engine-perspective-contract.test.js` (new)
+- `client/tests/python-parity.test.js` (new)
+- `client/tests/danish-gambit-regression.test.js` (new)
+- `client/tests/lazy-engine-comparison.test.js` (update mocks)
+- `client/tests/move-selector.test.js` (update mocks)
+- `client/tests/perspective-invariants.test.js` (update mocks)
 
 ---
 
-## Out of scope (flag in the PR description, don't fix here)
+## Verification
+
+- [ ] Failing tests in Step 5 land first; pass after Step 1-2.
+- [ ] `git grep -n "Math.abs(this.config.SOUNDNESSLIMIT\|Math.abs(this.config.LOSSLIMIT)"` → empty.
+- [ ] `git grep -n "centipawnLoss > Math.abs"` → empty.
+- [ ] `git grep -n "_handleMateScenarios"` → empty (function and all call sites removed).
+- [ ] `npm test` passes locally.
+- [ ] Manual browser repro: `Move Loss Limit = -20`, generate from `1. e4`
+      PGN, confirm Nf3 is chosen.
+
+---
+
+## Out of scope (flag in PR description)
 
 - `analyzeMove` caps depth at `Math.min(this.depth, 15)`
-  (`StockfishEngine.js:495`), which may underweight engine disagreement at
-  the configured deeper depths. Separate issue.
-- `_handleMateScenarios` "avoidable mate" branch was a JS-only extension;
-  removing it for Python parity. If users relied on it (probably not — it's
-  undocumented), revisit.
-- IGNORELOSSLIMIT itself was buggy in the JS port (used
-  `Math.abs(evaluation) < threshold` which fires symmetrically in losing
-  positions). The rewrite fixes it as a side effect.
+  (`StockfishEngine.js:495`) — may underweight engine disagreement at
+  deeper configured depths. Separate issue.
+- `_handleMateScenarios` "avoidable mate" was a JS-only extension (and
+  already dead for real engine output); removing for Python parity.
+- IGNORELOSSLIMIT JS bug (`Math.abs(evaluation) < threshold` firing
+  symmetrically in losing positions) — fixed as a side effect of Step 2a.

--- a/client/app.html
+++ b/client/app.html
@@ -2100,7 +2100,7 @@
                             <label class="form-label" for="soundness-limit">Soundness Limit (centipawns)</label>
                             <input type="number" id="soundness-limit" name="soundness-limit" class="form-input" value="-99">
                             <div class="form-help">
-                                The worst engine evaluation you're willing to accept for a higher winrate move. Centipawns measure position advantage: 100 = 1 pawn ahead, -100 = 1 pawn behind. Example: -300 means you'd accept being down 3 pawns if the winrate is good. The default -99 is very lenient (nearly 1 pawn). Forced mates are never accepted.
+                                The worst engine evaluation you're willing to accept for a higher winrate move. Centipawns measure position advantage: 100 = 1 pawn ahead, -100 = 1 pawn behind. Example: -300 means you'd accept being down 3 pawns if the winrate is good. The default -99 is very lenient (nearly 1 pawn). Useful for avoiding objectively losing positions, not for choosing between two playable lines &mdash; use the Move Loss Limit for that. Forced mates that engine-best also walks into are accepted; avoidable mates are not.
                             </div>
                         </div>
 
@@ -2108,7 +2108,7 @@
                             <label class="form-label" for="move-loss-limit">Move Loss Limit (centipawns)</label>
                             <input type="number" id="move-loss-limit" name="move-loss-limit" class="form-input" value="-99">
                             <div class="form-help">
-                                How much evaluation you're willing to sacrifice on a single move to play something with a higher winrate. Example: -50 means you'd accept losing half a pawn of advantage for a better practical result. The default -99 is lenient. Being loose here (e.g., -50 to -100) is recommended since engine evaluations in openings can be inconsistent.
+                                How much evaluation you're willing to sacrifice vs the engine's best move to play something with a higher winrate. Example: -50 means you'd accept losing half a pawn of advantage compared to the engine pick. This is the knob to make the algorithm prefer engine-best moves &mdash; try -20 if you want to closely follow engine recommendations. The default -99 is lenient; being loose here (e.g., -50 to -100) is reasonable since engine evaluations in openings can be inconsistent.
                             </div>
                         </div>
                     </div>

--- a/client/src/algorithm/MoveSelector.js
+++ b/client/src/algorithm/MoveSelector.js
@@ -25,9 +25,18 @@
  *    (Using confidence intervals - see Statistics.js for explanation)
  *
  * KEY CONCEPTS:
- * - SOUNDNESS LIMIT: Maximum allowed "centipawn loss" from the best move
- *   If engine says e4 is +50 and d4 is +20, d4 has 30 centipawn loss
- *   (100 centipawns = 1 pawn advantage in chess evaluation)
+ * - SOUNDNESS LIMIT: Absolute eval floor (our POV, centipawns). A move whose
+ *   afterEvalOurs falls at or below this is rejected. Negative is looser; e.g.
+ *   -99 accepts positions down to ~1 pawn. Mirrors Python `SOUNDNESSLIMIT` in
+ *   origin/pythonlegacy:workerEngineReduce.py:268.
+ *
+ * - MOVE LOSS LIMIT (LOSSLIMIT): Maximum allowed signed drop vs. the engine's
+ *   best move (our POV, centipawns). Negative is looser; e.g. -50 admits any
+ *   candidate within 0.5 pawns of the engine's pick. This is the knob to make
+ *   the algorithm prefer engine-best moves.
+ *
+ * - IGNORELOSSLIMIT: If afterEvalOurs is above this, both gates are bypassed —
+ *   "we are winning by enough that small drops don't matter."
  *
  * - CONFIDENCE INTERVAL: Statistical range where the true win rate likely falls
  *   With few games, we're less confident, so the "lower bound" is lower
@@ -73,9 +82,9 @@ class MoveSelector {
      *
      * @param {Object} config - Configuration object with selection parameters
      *   @param {number} config.CAREABOUTENGINE - 1 to use engine validation, 0 to skip
-     *   @param {number} config.SOUNDNESSLIMIT - Max centipawn loss allowed (negative = stricter)
-     *   @param {number} config.LOSSLIMIT - Secondary loss threshold
-     *   @param {number} config.IGNORELOSSLIMIT - Eval threshold above which loss limit is ignored
+     *   @param {number} config.SOUNDNESSLIMIT - Absolute eval floor, our POV, centipawns (negative = looser)
+     *   @param {number} config.LOSSLIMIT - Max signed drop vs. engine best, centipawns (negative = looser)
+     *   @param {number} config.IGNORELOSSLIMIT - If afterEvalOurs exceeds this, all gates relaxed
      *   @param {number} config.MINPLAYRATE - Minimum play rate for move consideration (0-1)
      *   @param {number} config.MINGAMES - Minimum games required for statistical significance
      *   @param {number} config.ALPHA - Confidence level for statistical intervals (e.g., 0.05 = 95%)
@@ -88,12 +97,12 @@ class MoveSelector {
             // ---------------------------
             CAREABOUTENGINE: config.CAREABOUTENGINE ?? 1,  // 1 = validate with engine, 0 = skip
 
-            // Maximum allowed centipawn loss from best move
-            // -99 means moves can be up to 99 centipawns worse than engine's best
-            // Negative value is used because we compare: if (loss > Math.abs(SOUNDNESSLIMIT))
+            // Absolute eval floor (our POV, centipawns). afterEvalOurs must
+            // exceed this for a non-engine-best move to pass.
             SOUNDNESSLIMIT: config.SOUNDNESSLIMIT ?? -99,
 
-            // Secondary loss limit (for moves that aren't the engine's best)
+            // Max signed drop vs. engine best (our POV, centipawns). signedMoveLoss
+            // must exceed this. Negative is looser.
             LOSSLIMIT: config.LOSSLIMIT ?? -99,
 
             // Evaluation threshold where LOSSLIMIT is ignored
@@ -499,58 +508,10 @@ class MoveSelector {
    * @returns {boolean} True if move passes soundness check
    */
     validateMoveSoundness(fen, move, engineBestMove, moveAnalysis) {
-        log.log(`      🎯 [MoveSelector] validateMoveSoundness for ${move}:`);
-        log.log(`         CAREABOUTENGINE: ${this.config.CAREABOUTENGINE}`);
-
         if (this.config.CAREABOUTENGINE !== 1) {
-            log.log(`         ✅ Skipping engine validation (CAREABOUTENGINE != 1)`);
-            return true; // Skip engine validation if not caring about engine
-        }
-
-        // Check if it's the engine's best move
-        if (move === engineBestMove) {
-            log.log(`         ✅ Move ${move} is engine's best move`);
             return true;
         }
-
-        // Check centipawn loss against limits
-        const centipawnLoss = moveAnalysis ? moveAnalysis.moveLoss : 0;
-        log.log(`         Centipawn loss: ${centipawnLoss}, evaluation: ${moveAnalysis?.evaluation}`);
-        log.log(`         Limits - SOUNDNESSLIMIT: ${this.config.SOUNDNESSLIMIT}, LOSSLIMIT: ${this.config.LOSSLIMIT}, IGNORELOSSLIMIT: ${this.config.IGNORELOSSLIMIT}`);
-
-        // Runtime validation: Check that move analysis values are within expected bounds
-        // This catches bugs like perspective flip errors early in development
-        this._validateMoveAnalysis(moveAnalysis, `validateMoveSoundness(${move})`);
-
-        // Handle mate scenarios specially
-        if (this._isMateScore(moveAnalysis?.evaluation)) {
-            log.log(`         🏁 Mate score detected, handling specially`);
-            const mateResult = this._handleMateScenarios(moveAnalysis);
-            log.log(`         Mate scenario result: ${mateResult ? '✅ ACCEPTED' : '❌ REJECTED'}`);
-            return mateResult;
-        }
-
-        // Apply soundness limit
-        if (centipawnLoss > Math.abs(this.config.SOUNDNESSLIMIT)) {
-            log.log(`         ❌ Failed soundness limit: ${centipawnLoss} > ${Math.abs(this.config.SOUNDNESSLIMIT)}`);
-            return false;
-        }
-
-        // Apply loss limit with ignore threshold
-        if (centipawnLoss > Math.abs(this.config.LOSSLIMIT)) {
-            // Check if we're above ignore threshold (where loss limit doesn't apply)
-            const absoluteEval = Math.abs(moveAnalysis?.evaluation || 0);
-            log.log(`         Loss limit check: ${centipawnLoss} > ${Math.abs(this.config.LOSSLIMIT)}, absoluteEval: ${absoluteEval}`);
-            if (absoluteEval < this.config.IGNORELOSSLIMIT) {
-                log.log(`         ❌ Failed loss limit (below ignore threshold): ${absoluteEval} < ${this.config.IGNORELOSSLIMIT}`);
-                return false;
-            } else {
-                log.log(`         ✅ Loss limit ignored (above threshold): ${absoluteEval} >= ${this.config.IGNORELOSSLIMIT}`);
-            }
-        }
-
-        log.log(`         ✅ Passed all soundness checks`);
-        return true;
+        return this._passesSoundnessCheck(move, engineBestMove, moveAnalysis);
     }
 
     /**
@@ -603,34 +564,6 @@ class MoveSelector {
 
         // Normal centipawn comparison
         return engineMoveScore - ourMoveScore;
-    }
-
-    /**
-   * Handle mate scenario evaluation
-   * @param {Object} moveAnalysis - Engine analysis with mate information
-   * @returns {boolean} True if mate scenario is acceptable
-   */
-    _handleMateScenarios(moveAnalysis) {
-        if (!moveAnalysis || !this._isMateScore(moveAnalysis.evaluation)) {
-            return true;
-        }
-
-        // If we have mate in our favor, always accept
-        if (moveAnalysis.evaluation > MATE_SCORE_THRESHOLD) {
-            return true;
-        }
-
-        // If we're getting mated, check if it's forced or avoidable
-        if (moveAnalysis.evaluation < -MATE_SCORE_THRESHOLD) {
-            // If position was already lost before our move (beforeEval shows mate), accept (forced mate)
-            // beforeEval = position evaluation before our move = engine's best line evaluation
-            if (this._isMateScore(moveAnalysis.beforeEval) && moveAnalysis.beforeEval < -MATE_SCORE_THRESHOLD) {
-                return true;
-            }
-            return false; // Avoidable mate
-        }
-
-        return true;
     }
 
     /**
@@ -948,63 +881,56 @@ class MoveSelector {
     }
 
     /**
-     * Check if a move passes soundness thresholds
+     * Check if a move passes soundness thresholds.
      *
-     * A move is "sound" if it doesn't lose too much compared to the engine's best.
-     * This reuses the logic from validateMoveSoundness but is simplified for
-     * the lazy evaluation path.
+     * Mirrors origin/pythonlegacy:workerEngineReduce.py:268. A non-engine-best
+     * move passes iff any of:
+     *   1. afterEvalOurs > IGNORELOSSLIMIT (we're winning by enough), OR
+     *   2. signedMoveLoss >= 0 (our move is at least as good as engine best —
+     *      also covers "both lines mate against us equally"), OR
+     *   3. Both gates pass: afterEvalOurs > SOUNDNESSLIMIT (eval floor) AND
+     *      signedMoveLoss > LOSSLIMIT (relative drop vs. engine best).
      *
-     * SOUNDNESS CRITERIA:
-     * 1. If the move IS the engine's best move → always sound
-     * 2. If centipawn loss > SOUNDNESSLIMIT → reject
-     * 3. If centipawn loss > LOSSLIMIT AND position isn't very winning → reject
-     * 4. Otherwise → sound
+     * Fails closed when afterEvalOurs/signedMoveLoss are missing — defaulting
+     * to 0 would silently approve stale analysis objects via branch 2.
      *
      * @param {string} moveUci - Move in UCI format (e.g., 'e2e4')
      * @param {string} engineBestMove - Engine's recommended move in UCI format
      * @param {Object} analysis - Engine analysis for this move
-     *   @param {number} analysis.moveLoss - Centipawn loss vs best move
-     *   @param {number} analysis.evaluation - Position evaluation after move
+     *   @param {number} analysis.afterEvalOurs - Position eval after move, our POV
+     *   @param {number} analysis.signedMoveLoss - Signed drop vs engine best, our POV
      * @returns {boolean} True if move passes soundness check
      * @private
      */
     _passesSoundnessCheck(moveUci, engineBestMove, analysis) {
-        // Fast path: engine's best move is always sound
-        if (moveUci === engineBestMove) {
-            log.log(`      ✅ ${moveUci} is engine's best move - automatically sound`);
-            return true;
-        }
+        // Fast path: engine's best move is always sound.
+        if (moveUci === engineBestMove) return true;
 
-        // Get centipawn loss from analysis (default to 0 if missing)
-        const centipawnLoss = analysis?.moveLoss || 0;
-
-        log.log(`      🔍 Checking soundness for ${moveUci}: loss=${centipawnLoss}cp, eval=${analysis?.evaluation}`);
-
-        // Runtime validation: Check that analysis values are within expected bounds
         this._validateMoveAnalysis(analysis, `_passesSoundnessCheck(${moveUci})`);
 
-        // Check SOUNDNESSLIMIT (strictest threshold)
-        // Note: SOUNDNESSLIMIT is stored as negative (e.g., -99) so we use Math.abs
-        if (centipawnLoss > Math.abs(this.config.SOUNDNESSLIMIT)) {
-            log.log(`      ❌ Failed SOUNDNESSLIMIT: ${centipawnLoss} > ${Math.abs(this.config.SOUNDNESSLIMIT)}`);
+        // Fail closed if required fields are missing — defaulting to 0 would
+        // silently approve stale analysis objects via the signedMoveLoss >= 0
+        // escape below.
+        const afterEval = analysis?.afterEvalOurs;
+        const signedMoveLoss = analysis?.signedMoveLoss;
+        if (!Number.isFinite(afterEval) || !Number.isFinite(signedMoveLoss)) {
+            log.warn(
+                `_passesSoundnessCheck(${moveUci}): missing afterEvalOurs/signedMoveLoss; rejecting`
+            );
             return false;
         }
 
-        // Check LOSSLIMIT (can be ignored if position is very winning)
-        if (centipawnLoss > Math.abs(this.config.LOSSLIMIT)) {
-            const absoluteEval = Math.abs(analysis?.evaluation || 0);
+        // Mirror origin/pythonlegacy:workerEngineReduce.py:268. Three OR branches:
+        //   1. Position is winning enough that we relax both gates (IGNORELOSSLIMIT).
+        //   2. signedMoveLoss >= 0 — our move is at least as good as engine best.
+        //      Also covers "mate-against-us when engine best is equally mating
+        //      against us" (both eval to -mate, so signedMoveLoss == 0).
+        //   3. Both gates pass: absolute eval floor AND relative drop.
+        if (afterEval > this.config.IGNORELOSSLIMIT) return true;
+        if (signedMoveLoss >= 0) return true;
 
-            // If we're already winning by a lot, ignore the loss limit
-            if (absoluteEval < this.config.IGNORELOSSLIMIT) {
-                log.log(`      ❌ Failed LOSSLIMIT: ${centipawnLoss} > ${Math.abs(this.config.LOSSLIMIT)} and eval ${absoluteEval} < ${this.config.IGNORELOSSLIMIT}`);
-                return false;
-            } else {
-                log.log(`      ✅ LOSSLIMIT exceeded but ignored (eval ${absoluteEval} >= ${this.config.IGNORELOSSLIMIT})`);
-            }
-        }
-
-        log.log(`      ✅ Passed all soundness checks`);
-        return true;
+        return afterEval > this.config.SOUNDNESSLIMIT
+            && signedMoveLoss > this.config.LOSSLIMIT;
     }
 
     /**

--- a/client/src/config/sample-openings.js
+++ b/client/src/config/sample-openings.js
@@ -110,12 +110,12 @@ export const sampleOpenings = {
       // Engine Finishing - use engine when database runs out
       engineFinishing: true,
 
-      // Soundness Limit (centipawns) - max eval we'll accept
-      // -99 means we accept positions up to -0.99 pawns
+      // Soundness Limit (centipawns) - absolute eval floor we'll accept (our POV)
+      // -99 means we accept positions down to about 1 pawn worse
       soundnessLimit: -99,
 
-      // Move Loss Limit (centipawns) - max eval loss per move
-      // -50 means we won't play a move that loses more than 0.5 pawns
+      // Move Loss Limit (centipawns) - max signed drop vs engine best
+      // -50 means we won't play a move that loses more than 0.5 pawns vs engine pick
       moveLossLimit: -50,
 
       // Ignore Loss Limit - if we're ahead by this much, ignore move loss
@@ -155,7 +155,8 @@ export const sampleOpenings = {
       opponentMinGames: 20,
       // London is solid, so we can be less strict about engine settings
       engineEnabled: true,
-      soundnessLimit: -150
+      soundnessLimit: -300,
+      moveLossLimit: -100
     },
 
     {
@@ -186,6 +187,7 @@ export const sampleOpenings = {
       rating2000: true,
       rating2200: true,
       rating2500: true,
+      soundnessLimit: -50,     // Strict eval floor
       moveLossLimit: -30,      // Be strict about not losing eval
       mostPlayedMoves: 3       // Focus on main lines only
     },

--- a/client/src/engine/MockStockfishEngine.js
+++ b/client/src/engine/MockStockfishEngine.js
@@ -212,8 +212,9 @@ class MockStockfishEngine {
         const beforeEval = scenario.evaluation;
         const afterEval = -(scenario.evaluation - 5); // Slight change after move
 
-        // Calculate move quality (mock values)
-        const moveLoss = Math.abs(5); // Small loss for mock
+        const afterEvalOurs = -afterEval;
+        const signedMoveLoss = afterEvalOurs - beforeEval;
+        const moveLoss = Math.abs(signedMoveLoss);
         const quality = this._calculateMoveQuality(moveLoss);
 
         return {
@@ -221,7 +222,9 @@ class MockStockfishEngine {
             moveLoss: moveLoss,
             quality: quality,
             beforeEval: beforeEval,
-            afterEval: afterEval
+            afterEval: afterEval,
+            afterEvalOurs,
+            signedMoveLoss
         };
     }
 

--- a/client/src/engine/NodeStockfishEngine.js
+++ b/client/src/engine/NodeStockfishEngine.js
@@ -524,18 +524,20 @@ class NodeStockfishEngine {
             // - adjustedAfterEval = -200 (from white's perspective)
             // - moveLoss = 30 - (-200) = 230 cp (white lost 230 cp, blunder!)
             const adjustedAfterEval = -afterEval;
-            const moveLoss = beforeEval - adjustedAfterEval;
-
-            // Use absolute value for quality assessment (we care about magnitude)
-            const absMoveLoss = Math.abs(moveLoss);
+            // Signed delta vs. engine-best line (negative = our move is worse).
+            // Mirrors origin/pythonlegacy:workerEngineReduce.py:268.
+            const signedMoveLoss = adjustedAfterEval - beforeEval;
+            const absMoveLoss = Math.abs(signedMoveLoss);
             const quality = this.calculateMoveQuality(absMoveLoss);
 
             return {
-                evaluation: afterEval,
-                moveLoss: absMoveLoss,
+                evaluation: afterEval,              // raw, opponent POV
+                moveLoss: absMoveLoss,              // magnitude (quality UI)
                 quality,
-                beforeEval,
-                afterEval
+                beforeEval,                         // our POV
+                afterEval,                          // raw, opponent POV
+                afterEvalOurs: adjustedAfterEval,   // our POV, signed
+                signedMoveLoss                      // our POV, signed (neg = worse)
             };
 
         } catch (error) {

--- a/client/src/engine/StockfishEngine.js
+++ b/client/src/engine/StockfishEngine.js
@@ -519,22 +519,21 @@ class StockfishEngine {
             // - moveLoss = 30 - (-200) = 230 cp (white lost 230 cp, blunder!)
             // Flip perspective: negate afterEval so both values are from the same side's POV
             const adjustedAfterEval = -afterEval;
-            // Calculate how much the position changed (positive = got worse for the moving side)
-            const moveLoss = beforeEval - adjustedAfterEval;
-
-            // Use absolute value for quality assessment (we care about magnitude, not direction)
-            // A loss of 30cp and a gain of 30cp should both map to the same quality tier
-            const absMoveLoss = Math.abs(moveLoss);
-            // Convert centipawn loss to human-readable quality label ('excellent', 'good', 'poor', etc.)
+            // Signed delta vs. engine-best line (negative = our move is worse).
+            // Mirrors origin/pythonlegacy:workerEngineReduce.py:268.
+            const signedMoveLoss = adjustedAfterEval - beforeEval;
+            // Magnitude (positive) for quality tier display.
+            const absMoveLoss = Math.abs(signedMoveLoss);
             const quality = this.calculateMoveQuality(absMoveLoss);
 
-            // Return analysis results with all the data callers might need
             return {
-                evaluation: afterEval,      // Position score after move (opponent's perspective)
-                moveLoss: absMoveLoss,      // Centipawn loss magnitude (always positive)
-                quality,                    // Human-readable quality rating
-                beforeEval,                 // Position score before move (our perspective)
-                afterEval                   // Raw after-move score (for debugging)
+                evaluation: afterEval,              // raw, opponent POV
+                moveLoss: absMoveLoss,              // magnitude (quality UI)
+                quality,
+                beforeEval,                         // our POV
+                afterEval,                          // raw, opponent POV
+                afterEvalOurs: adjustedAfterEval,   // our POV, signed
+                signedMoveLoss                      // our POV, signed (neg = worse)
             };
 
         } catch (error) {

--- a/client/tests/config-behavior.test.js
+++ b/client/tests/config-behavior.test.js
@@ -590,8 +590,11 @@ describe('SOUNDNESSLIMIT and LOSSLIMIT Configuration Behavior', () => {
             LOSSLIMIT: -300
         });
 
-        // Move that loses 75 centipawns
-        const moveAnalysis = { evaluation: -25, moveLoss: 75 };
+        // Move loses 75cp; afterEvalOurs = -75 (below strict floor -50, above loose floor -200)
+        const moveAnalysis = {
+            evaluation: 75, afterEval: 75, beforeEval: 0,
+            afterEvalOurs: -75, signedMoveLoss: -75, moveLoss: 75
+        };
 
         // ACT
         const strictResult = await strictSelector.validateMoveSoundness(
@@ -602,8 +605,8 @@ describe('SOUNDNESSLIMIT and LOSSLIMIT Configuration Behavior', () => {
         );
 
         // ASSERT
-        // Strict: 75 > 50 = FAIL
-        // Loose: 75 > 200 = PASS (within limit)
+        // Strict: afterEvalOurs -75 < SOUNDNESSLIMIT -50 → FAIL
+        // Loose:  afterEvalOurs -75 > SOUNDNESSLIMIT -200 and -75 > LOSSLIMIT -300 → PASS
         expect(strictResult).toBe(false);
         expect(looseResult).toBe(true);
     });
@@ -617,11 +620,17 @@ describe('SOUNDNESSLIMIT and LOSSLIMIT Configuration Behavior', () => {
             IGNORELOSSLIMIT: 300   // But ignore when eval > 300
         });
 
-        // Move loses 75cp but position is +400 (winning)
-        const winningPosition = { evaluation: 400, moveLoss: 75 };
+        // Move loses 75cp but afterEvalOurs is +400 (winning)
+        const winningPosition = {
+            evaluation: -400, afterEval: -400, beforeEval: 475,
+            afterEvalOurs: 400, signedMoveLoss: -75, moveLoss: 75
+        };
 
-        // Same loss but position is +100 (slight advantage)
-        const slightAdvantage = { evaluation: 100, moveLoss: 75 };
+        // Same loss but afterEvalOurs is +100 (slight advantage)
+        const slightAdvantage = {
+            evaluation: -100, afterEval: -100, beforeEval: 175,
+            afterEvalOurs: 100, signedMoveLoss: -75, moveLoss: 75
+        };
 
         // ACT
         const winningResult = await selector.validateMoveSoundness(

--- a/client/tests/danish-gambit-regression.test.js
+++ b/client/tests/danish-gambit-regression.test.js
@@ -1,0 +1,108 @@
+/**
+ * Regression: with a strict Move Loss Limit, MoveSelector should reject the
+ * Danish-Gambit move (d4 after 1.e4 e5) when its signedMoveLoss is below the
+ * configured threshold, and accept it when the threshold is loosened.
+ *
+ * Pre-fix the JS port compared Math.abs(LOSSLIMIT) against magnitude, which
+ * silently passed d4 through; this test pins the Python semantics.
+ */
+import MoveSelector from '../src/algorithm/MoveSelector.js';
+import Statistics from '../src/stats/Statistics.js';
+
+const FEN_AFTER_1E4_E5 =
+    'rnbqkbnr/pppp1ppp/8/4p3/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2';
+
+const CANDIDATES = [
+    { san: 'Nf3', uci: 'g1f3', white: 1000000, black: 800000, draws: 200000, playrate: 0.5 },
+    { san: 'd4',  uci: 'd2d4', white: 1100000, black: 700000, draws: 200000, playrate: 0.3 },
+    { san: 'Bc4', uci: 'f1c4', white: 500000,  black: 450000, draws: 100000, playrate: 0.2 }
+];
+
+class DanishMockEngine {
+    constructor() {
+        this.bestMove = 'g1f3';
+    }
+
+    async getBestMove() {
+        return this.bestMove;
+    }
+
+    async evaluatePosition() {
+        return 20; // White slight edge (white POV)
+    }
+
+    async analyzeMove(_fen, moveUci) {
+        if (moveUci === 'g1f3') {
+            return {
+                evaluation: -20, afterEval: -20, beforeEval: 20,
+                afterEvalOurs: 20, signedMoveLoss: 0, moveLoss: 0,
+                quality: 'excellent'
+            };
+        }
+        if (moveUci === 'd2d4') {
+            // d4 our POV eval = -5, before = 20 → signedMoveLoss = -25
+            return {
+                evaluation: 5, afterEval: 5, beforeEval: 20,
+                afterEvalOurs: -5, signedMoveLoss: -25, moveLoss: 25,
+                quality: 'good'
+            };
+        }
+        if (moveUci === 'f1c4') {
+            return {
+                evaluation: -15, afterEval: -15, beforeEval: 20,
+                afterEvalOurs: 15, signedMoveLoss: -5, moveLoss: 5,
+                quality: 'excellent'
+            };
+        }
+        throw new Error(`Unexpected move: ${moveUci}`);
+    }
+}
+
+describe('Danish Gambit regression — Move Loss Limit honored', () => {
+    test('LOSSLIMIT=-10 rejects d4 (signedMoveLoss=-25 < -10)', async () => {
+        const selector = new MoveSelector({
+            CAREABOUTENGINE: 1,
+            LAZY_ENGINE: 1,
+            SOUNDNESSLIMIT: -300,
+            LOSSLIMIT: -10,
+            IGNORELOSSLIMIT: 300,
+            MINPLAYRATE: 0,
+            MINGAMES: 0,
+            ALPHA: 0.05
+        });
+
+        const result = await selector.selectBestMove(
+            { fen: FEN_AFTER_1E4_E5, perspective: 'white' },
+            CANDIDATES,
+            new DanishMockEngine(),
+            new Statistics()
+        );
+
+        expect(result.selectedMove.uci).toBe('g1f3');
+    });
+
+    test('LOSSLIMIT=-50 admits d4 (signedMoveLoss=-25 > -50)', async () => {
+        const selector = new MoveSelector({
+            CAREABOUTENGINE: 1,
+            LAZY_ENGINE: 1,
+            SOUNDNESSLIMIT: -300,
+            LOSSLIMIT: -50,
+            IGNORELOSSLIMIT: 300,
+            MINPLAYRATE: 0,
+            MINGAMES: 0,
+            ALPHA: 0.05
+        });
+
+        const result = await selector.selectBestMove(
+            { fen: FEN_AFTER_1E4_E5, perspective: 'white' },
+            CANDIDATES,
+            new DanishMockEngine(),
+            new Statistics()
+        );
+
+        // d4 is admissible; whether it wins on stats depends on lower-bound calc.
+        // Either way, the engine should not have rejected d4 like it does at -10.
+        expect(['g1f3', 'd2d4', 'f1c4']).toContain(result.selectedMove.uci);
+        expect(result.selectionReason).not.toMatch(/rejected/i);
+    });
+});

--- a/client/tests/engine-perspective-contract.test.js
+++ b/client/tests/engine-perspective-contract.test.js
@@ -1,0 +1,45 @@
+/**
+ * Engine perspective contract: the analyzeMove() return must include
+ * afterEvalOurs and signedMoveLoss in our POV, with the right sign for
+ * a position where the moving side blunders.
+ */
+import { MockStockfishEngine } from '../src/engine/MockStockfishEngine.js';
+
+describe('engine analyzeMove() perspective contract', () => {
+    test('returns afterEvalOurs and signedMoveLoss in our POV (losing scenario)', async () => {
+        const engine = new MockStockfishEngine();
+        await engine.initialize();
+        engine.setScenario('losing'); // negative evaluation for side to move
+
+        const analysis = await engine.analyzeMove(
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            'a2a4'
+        );
+
+        expect(Number.isFinite(analysis.afterEvalOurs)).toBe(true);
+        expect(Number.isFinite(analysis.signedMoveLoss)).toBe(true);
+        expect(analysis.afterEvalOurs).toBeLessThan(0);
+        expect(analysis.signedMoveLoss).toBeLessThanOrEqual(0);
+
+        // Backward-compat fields preserved.
+        expect(analysis.moveLoss).toBeGreaterThanOrEqual(0);
+        expect(typeof analysis.evaluation).toBe('number');
+
+        await engine.shutdown();
+    });
+
+    test('our POV winning scenario produces positive afterEvalOurs', async () => {
+        const engine = new MockStockfishEngine();
+        await engine.initialize();
+        engine.setScenario('winning');
+
+        const analysis = await engine.analyzeMove(
+            'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1',
+            'e2e4'
+        );
+
+        expect(analysis.afterEvalOurs).toBeGreaterThan(0);
+
+        await engine.shutdown();
+    });
+});

--- a/client/tests/error-handling/MoveSelector.test.js
+++ b/client/tests/error-handling/MoveSelector.test.js
@@ -153,72 +153,64 @@ describe('MoveSelector Error Handling', () => {
         });
     });
 
-    describe('Mate Scenario Handling', () => {
+    describe('Mate Scenarios (via _passesSoundnessCheck)', () => {
+        // Real engines emit ±10000 for mate (StockfishEngine.js / NodeStockfishEngine.js);
+        // these tests exercise the soundness rule for those values.
+        const MATE_FOR_US = 10000;
+        const MATE_AGAINST_US = -10000;
+
         let moveSelector;
 
         beforeEach(() => {
             moveSelector = new MoveSelector({
                 CAREABOUTENGINE: 1,
-                SOUNDNESSLIMIT: -99
+                SOUNDNESSLIMIT: -99,
+                LOSSLIMIT: -99,
+                IGNORELOSSLIMIT: 300
             });
         });
 
-        it('accepts move leading to mate when position was already a forced mate', () => {
-            // Scenario: Position is already lost (forced mate against us).
-            // Our move also leads to mate, but that's fine - we can't do better.
-            // The bug: code referenced moveAnalysis.bestEvaluation which doesn't exist.
-            // Fix: should use moveAnalysis.beforeEval instead.
-
-            const MATE_SCORE = -10000000; // Represents mate against us
-
+        it('accepts mate-against-us when engine best line is also mating against us', () => {
+            // Engine best also mates against us → signedMoveLoss == 0 → approved.
             const moveAnalysis = {
-                evaluation: MATE_SCORE,      // After our move: we get mated
-                beforeEval: MATE_SCORE,      // Before our move: already forced mate
-                moveLoss: 0,                 // No loss - position was already lost
+                evaluation: -MATE_AGAINST_US,
+                afterEval: -MATE_AGAINST_US,
+                beforeEval: MATE_AGAINST_US,
+                afterEvalOurs: MATE_AGAINST_US,
+                signedMoveLoss: 0,
+                moveLoss: 0,
                 quality: 'forced'
             };
 
-            // This should return true: forced mate, nothing we can do
-            const result = moveSelector._handleMateScenarios(moveAnalysis);
-
-            expect(result).toBe(true);
+            expect(moveSelector._passesSoundnessCheck('a1a2', 'e2e4', moveAnalysis)).toBe(true);
         });
 
-        it('rejects move leading to mate when mate was avoidable', () => {
-            // Scenario: Position was fine, but our move blunders into mate.
-            // beforeEval is normal (not mate), but evaluation after move is mate.
-
-            const MATE_SCORE = -10000000;
-            const NORMAL_EVAL = -50; // Slightly worse but not mate
-
+        it('rejects avoidable mate-against-us', () => {
             const moveAnalysis = {
-                evaluation: MATE_SCORE,      // After our move: we get mated
-                beforeEval: NORMAL_EVAL,     // Before our move: position was fine
-                moveLoss: 9999950,           // Huge loss
+                evaluation: -MATE_AGAINST_US,
+                afterEval: -MATE_AGAINST_US,
+                beforeEval: -50,
+                afterEvalOurs: MATE_AGAINST_US,
+                signedMoveLoss: MATE_AGAINST_US - -50, // very negative
+                moveLoss: Math.abs(MATE_AGAINST_US - -50),
                 quality: 'blunder'
             };
 
-            // This should return false: we blundered into an avoidable mate
-            const result = moveSelector._handleMateScenarios(moveAnalysis);
-
-            expect(result).toBe(false);
+            expect(moveSelector._passesSoundnessCheck('a1a2', 'e2e4', moveAnalysis)).toBe(false);
         });
 
-        it('accepts move that gives us mate', () => {
-            // Scenario: Our move delivers checkmate. Always accept!
-
-            const MATE_SCORE = 10000000; // Mate in our favor
-
+        it('accepts mate-for-us (clears IGNORELOSSLIMIT)', () => {
             const moveAnalysis = {
-                evaluation: MATE_SCORE,      // After our move: we deliver mate
-                beforeEval: 100,             // Before: we were winning
-                moveLoss: 0,
+                evaluation: -MATE_FOR_US,
+                afterEval: -MATE_FOR_US,
+                beforeEval: 100,
+                afterEvalOurs: MATE_FOR_US,
+                signedMoveLoss: MATE_FOR_US - 100,
+                moveLoss: MATE_FOR_US - 100,
                 quality: 'checkmate'
             };
 
-            const result = moveSelector._handleMateScenarios(moveAnalysis);
-
-            expect(result).toBe(true);
+            expect(moveSelector._passesSoundnessCheck('h5h8', 'e2e4', moveAnalysis)).toBe(true);
         });
     });
 });

--- a/client/tests/lazy-engine-comparison.test.js
+++ b/client/tests/lazy-engine-comparison.test.js
@@ -106,10 +106,15 @@ class CountingMockEngine {
         const isBestMove = move === this.bestMove;
         const moveLoss = this.moveLosses[move] ?? (isBestMove ? 0 : 30);
 
+        const afterEvalOurs = this.positionEval - moveLoss;
         return {
             move,
             bestMove: this.bestMove,
-            evaluation: this.positionEval - moveLoss,
+            evaluation: -afterEvalOurs,
+            afterEval: -afterEvalOurs,
+            beforeEval: this.positionEval,
+            afterEvalOurs,
+            signedMoveLoss: -moveLoss,
             bestEvaluation: this.positionEval,
             moveLoss,
             isBestMove,

--- a/client/tests/move-selector-semantics.test.js
+++ b/client/tests/move-selector-semantics.test.js
@@ -1,0 +1,129 @@
+/**
+ * Soundness/move-loss semantic regression tests.
+ *
+ * Mirrors origin/pythonlegacy:workerEngineReduce.py:268. Verifies that:
+ *   - SOUNDNESSLIMIT acts as an absolute eval floor (our POV)
+ *   - LOSSLIMIT acts as a signed delta vs engine-best (negative = looser)
+ *   - IGNORELOSSLIMIT escape only kicks in when we are actually winning that much
+ *   - signedMoveLoss >= 0 escape approves moves at least as good as engine-best
+ *   - missing afterEvalOurs/signedMoveLoss → reject (fail closed)
+ */
+import MoveSelector from '../src/algorithm/MoveSelector.js';
+
+const CONFIG_DEFAULTS = {
+    CAREABOUTENGINE: 1,
+    MINPLAYRATE: 0,
+    MINGAMES: 0,
+    ALPHA: 0.05,
+    LAZY_ENGINE: 1
+};
+
+function makeSelector({ SOUNDNESSLIMIT, LOSSLIMIT, IGNORELOSSLIMIT }) {
+    return new MoveSelector({
+        ...CONFIG_DEFAULTS,
+        SOUNDNESSLIMIT,
+        LOSSLIMIT,
+        IGNORELOSSLIMIT
+    });
+}
+
+describe('_passesSoundnessCheck — Python parity semantics', () => {
+    const cases = [
+        // [name, afterEvalOurs, signedMoveLoss, SOUND, LOSS, IGNORE, expect]
+        ['within both limits',           -50,  -70,  -99,  -99, 300, true],
+        ['eval-floor violation',        -150, -170,  -99,  -99, 300, false],
+        ['strict floor, lax move-loss',  -80,  -50,  -50,  -99, 300, false],
+        ['move-loss violation',         -150, -200,  -99, -100, 300, false],
+        ['IGNORELOSSLIMIT escape',      +400, +380,  -99,  -99, 300, true],
+        ['both gates fail',             -200, -220,  -99,  -99, 300, false],
+        ['engine likes our move',        +50,  +30,  -99,  -99, 300, true],
+        ['mate for us',               +10000, +999,  -99,  -99, 300, true],
+        ['avoidable mate against us', -10000, -9000, -99,  -99, 300, false],
+        ['equal mate against us',     -10000,    0,  -99,  -99, 300, true],
+        ['positive floor accepts',       +80,  +30,  +50,  -99, 300, true],
+        ['positive floor rejects',       +30,  -20,  +50,  -99, 300, false]
+    ];
+
+    test.each(cases)(
+        '%s',
+        (_name, afterEvalOurs, signedMoveLoss, SOUND, LOSS, IGNORE, expected) => {
+            const selector = makeSelector({
+                SOUNDNESSLIMIT: SOUND,
+                LOSSLIMIT: LOSS,
+                IGNORELOSSLIMIT: IGNORE
+            });
+
+            const analysis = {
+                afterEvalOurs,
+                signedMoveLoss,
+                evaluation: -afterEvalOurs,
+                afterEval: -afterEvalOurs,
+                moveLoss: Math.abs(signedMoveLoss),
+                beforeEval: afterEvalOurs - signedMoveLoss
+            };
+
+            expect(
+                selector._passesSoundnessCheck('d2d4', 'e2e4', analysis)
+            ).toBe(expected);
+        }
+    );
+
+    test('fails closed when afterEvalOurs/signedMoveLoss missing', () => {
+        const selector = makeSelector({
+            SOUNDNESSLIMIT: -99,
+            LOSSLIMIT: -99,
+            IGNORELOSSLIMIT: 300
+        });
+
+        const staleAnalysis = { evaluation: -50, moveLoss: 30 };
+
+        expect(
+            selector._passesSoundnessCheck('d2d4', 'e2e4', staleAnalysis)
+        ).toBe(false);
+    });
+
+    test('engine best move always passes (no analysis needed)', () => {
+        const selector = makeSelector({
+            SOUNDNESSLIMIT: -10,
+            LOSSLIMIT: -5,
+            IGNORELOSSLIMIT: 1000
+        });
+
+        expect(selector._passesSoundnessCheck('e2e4', 'e2e4', null)).toBe(true);
+    });
+
+    test('validateMoveSoundness delegates to _passesSoundnessCheck', () => {
+        const selector = makeSelector({
+            SOUNDNESSLIMIT: -99,
+            LOSSLIMIT: -99,
+            IGNORELOSSLIMIT: 300
+        });
+
+        const analysis = {
+            afterEvalOurs: -150,
+            signedMoveLoss: -170,
+            evaluation: 150,
+            afterEval: 150,
+            moveLoss: 170,
+            beforeEval: 20
+        };
+
+        expect(
+            selector.validateMoveSoundness(null, 'd2d4', 'e2e4', analysis)
+        ).toBe(false);
+    });
+
+    test('CAREABOUTENGINE=0 bypasses all checks via validateMoveSoundness', () => {
+        const selector = new MoveSelector({
+            ...CONFIG_DEFAULTS,
+            CAREABOUTENGINE: 0,
+            SOUNDNESSLIMIT: -10,
+            LOSSLIMIT: -5,
+            IGNORELOSSLIMIT: 1000
+        });
+
+        expect(
+            selector.validateMoveSoundness(null, 'd2d4', 'e2e4', null)
+        ).toBe(true);
+    });
+});

--- a/client/tests/move-selector.test.js
+++ b/client/tests/move-selector.test.js
@@ -25,13 +25,19 @@ class MockEngineClient {
     async analyzeMove(fen, move) {
         const baseEval = this.evaluations[fen] || 25;
         const isBestMove = move === this.bestMove;
+        const afterEvalOurs = isBestMove ? baseEval : baseEval - 30;
+        const signedMoveLoss = afterEvalOurs - baseEval;
 
         return {
             move,
             bestMove: this.bestMove,
-            evaluation: isBestMove ? baseEval : baseEval - 30,
+            evaluation: -afterEvalOurs,
+            afterEval: -afterEvalOurs,
+            beforeEval: baseEval,
+            afterEvalOurs,
+            signedMoveLoss,
             bestEvaluation: baseEval,
-            moveLoss: isBestMove ? 0 : 30,
+            moveLoss: Math.abs(signedMoveLoss),
             isBestMove,
             quality: isBestMove ? 'excellent' : 'good'
         };
@@ -146,11 +152,11 @@ describe('MoveSelector - Step 4: Move Selection Algorithm', () => {
         test('validates move soundness against engine limits', async () => {
             const fen = TestUtils.createTestPosition('starting').fen;
 
-            // Test move that passes soundness check
+            // Engine-best always passes regardless of analysis content.
             const goodAnalysis = {
-                evaluation: 25,
-                bestEvaluation: 30,
-                moveLoss: 5
+                evaluation: -25, afterEval: -25, beforeEval: 25,
+                afterEvalOurs: 25, signedMoveLoss: 0,
+                bestEvaluation: 30, moveLoss: 0
             };
 
             const isGoodSound = await moveSelector.validateMoveSoundness(
@@ -161,11 +167,11 @@ describe('MoveSelector - Step 4: Move Selection Algorithm', () => {
             );
             expect(isGoodSound).toBe(true);
 
-            // Test move that fails soundness check
+            // Non-best move with afterEvalOurs below SOUNDNESSLIMIT (-50) → fail.
             const badAnalysis = {
-                evaluation: -25,
-                bestEvaluation: 30,
-                moveLoss: 55 // Exceeds SOUNDNESSLIMIT of 50
+                evaluation: 60, afterEval: 60, beforeEval: 10,
+                afterEvalOurs: -60, signedMoveLoss: -70,
+                bestEvaluation: 30, moveLoss: 70
             };
 
             const isBadSound = await moveSelector.validateMoveSoundness(
@@ -213,11 +219,11 @@ describe('MoveSelector - Step 4: Move Selection Algorithm', () => {
             });
             const selector = new MoveSelector(config);
 
-            // Move with high loss but below ignore threshold - should fail
+            // signedMoveLoss -50 < LOSSLIMIT -30, afterEvalOurs 50 below IGNORE → fail.
             const lowEvalAnalysis = {
-                evaluation: 50, // Below ignore threshold
-                bestEvaluation: 100,
-                moveLoss: 50 // Exceeds loss limit
+                evaluation: -50, afterEval: -50, beforeEval: 100,
+                afterEvalOurs: 50, signedMoveLoss: -50,
+                bestEvaluation: 100, moveLoss: 50
             };
 
             const shouldFail = await selector.validateMoveSoundness(
@@ -228,11 +234,11 @@ describe('MoveSelector - Step 4: Move Selection Algorithm', () => {
             );
             expect(shouldFail).toBe(false);
 
-            // Move with high loss but above ignore threshold - should pass
+            // afterEvalOurs 250 > IGNORELOSSLIMIT 200 → all gates relaxed.
             const highEvalAnalysis = {
-                evaluation: 250, // Above ignore threshold
-                bestEvaluation: 300,
-                moveLoss: 50 // Same loss but threshold applies
+                evaluation: -250, afterEval: -250, beforeEval: 300,
+                afterEvalOurs: 250, signedMoveLoss: -50,
+                bestEvaluation: 300, moveLoss: 50
             };
 
             const shouldPass = await selector.validateMoveSoundness(
@@ -430,117 +436,78 @@ describe('MoveSelector - Step 4: Move Selection Algorithm', () => {
     });
 
     // =========================================================================
-    // CENTIPAWN BOUNDARY EDGE CASES
+    // SOUNDNESS BOUNDARY EDGE CASES
     // =========================================================================
-    // These tests verify the soundness limit logic handles boundary conditions
-    // correctly. We use mocked analysis to get deterministic results.
-    describe('Centipawn Boundary Edge Cases', () => {
+    // Verifies the new Python-parity semantics:
+    //   SOUNDNESSLIMIT = absolute eval floor (our POV; negative = looser)
+    //   LOSSLIMIT     = signed delta vs engine-best (negative = looser)
+    //   IGNORELOSSLIMIT = if afterEvalOurs > this, relax all gates
+    describe('Soundness Boundary Edge Cases', () => {
 
-        describe('SOUNDNESSLIMIT boundary', () => {
-            test('moveLoss exactly at SOUNDNESSLIMIT passes', () => {
-                // SOUNDNESSLIMIT is -50, so Math.abs gives 50
-                // moveLoss of exactly 50 should pass (not greater than 50)
-                const selectorWithLimit = new MoveSelector({
+        const makeAnalysis = (afterEvalOurs, signedMoveLoss) => ({
+            afterEvalOurs,
+            signedMoveLoss,
+            evaluation: -afterEvalOurs,
+            afterEval: -afterEvalOurs,
+            beforeEval: afterEvalOurs - signedMoveLoss,
+            moveLoss: Math.abs(signedMoveLoss)
+        });
+
+        describe('SOUNDNESSLIMIT (eval floor)', () => {
+            test('afterEvalOurs above floor passes', () => {
+                const selector = new MoveSelector({
                     CAREABOUTENGINE: 1,
-                    SOUNDNESSLIMIT: -50,
-                    LOSSLIMIT: -100,
-                    IGNORELOSSLIMIT: 300
+                    SOUNDNESSLIMIT: -50, LOSSLIMIT: -100, IGNORELOSSLIMIT: 300
                 });
-
-                const analysis = { moveLoss: 50, evaluation: 20 };
-                const result = selectorWithLimit.validateMoveSoundness(
-                    null, 'd2d4', 'e2e4', analysis
-                );
-
-                expect(result).toBe(true);
+                expect(selector.validateMoveSoundness(null, 'd2d4', 'e2e4',
+                    makeAnalysis(-40, -30))).toBe(true);
             });
 
-            test('moveLoss just above SOUNDNESSLIMIT fails', () => {
-                const selectorWithLimit = new MoveSelector({
+            test('afterEvalOurs at floor fails (strict >)', () => {
+                const selector = new MoveSelector({
                     CAREABOUTENGINE: 1,
-                    SOUNDNESSLIMIT: -50,
-                    LOSSLIMIT: -100,
-                    IGNORELOSSLIMIT: 300
+                    SOUNDNESSLIMIT: -50, LOSSLIMIT: -100, IGNORELOSSLIMIT: 300
                 });
-
-                const analysis = { moveLoss: 51, evaluation: 20 };
-                const result = selectorWithLimit.validateMoveSoundness(
-                    null, 'd2d4', 'e2e4', analysis
-                );
-
-                expect(result).toBe(false);
+                expect(selector.validateMoveSoundness(null, 'd2d4', 'e2e4',
+                    makeAnalysis(-50, -30))).toBe(false);
             });
 
-            test('moveLoss of zero always passes SOUNDNESSLIMIT', () => {
-                const selectorWithLimit = new MoveSelector({
+            test('afterEvalOurs below floor fails', () => {
+                const selector = new MoveSelector({
                     CAREABOUTENGINE: 1,
-                    SOUNDNESSLIMIT: -50,
-                    LOSSLIMIT: -100,
-                    IGNORELOSSLIMIT: 300
+                    SOUNDNESSLIMIT: -50, LOSSLIMIT: -100, IGNORELOSSLIMIT: 300
                 });
-
-                const analysis = { moveLoss: 0, evaluation: 20 };
-                const result = selectorWithLimit.validateMoveSoundness(
-                    null, 'd2d4', 'e2e4', analysis
-                );
-
-                expect(result).toBe(true);
+                expect(selector.validateMoveSoundness(null, 'd2d4', 'e2e4',
+                    makeAnalysis(-80, -30))).toBe(false);
             });
         });
 
         describe('LOSSLIMIT with IGNORELOSSLIMIT', () => {
-            test('moveLoss above LOSSLIMIT fails when eval below IGNORELOSSLIMIT', () => {
+            test('signedMoveLoss below LOSSLIMIT fails when not winning', () => {
                 const selector = new MoveSelector({
                     CAREABOUTENGINE: 1,
-                    SOUNDNESSLIMIT: -50,
-                    LOSSLIMIT: -30, // Stricter than SOUNDNESSLIMIT
-                    IGNORELOSSLIMIT: 300
+                    SOUNDNESSLIMIT: -50, LOSSLIMIT: -30, IGNORELOSSLIMIT: 300
                 });
-
-                // moveLoss 40 > LOSSLIMIT 30, but passes SOUNDNESSLIMIT 50
-                // eval 100 < IGNORELOSSLIMIT 300, so should fail
-                const analysis = { moveLoss: 40, evaluation: 100 };
-                const result = selector.validateMoveSoundness(
-                    null, 'd2d4', 'e2e4', analysis
-                );
-
-                expect(result).toBe(false);
+                expect(selector.validateMoveSoundness(null, 'd2d4', 'e2e4',
+                    makeAnalysis(-40, -40))).toBe(false);
             });
 
-            test('moveLoss above LOSSLIMIT passes when eval above IGNORELOSSLIMIT', () => {
+            test('LOSSLIMIT ignored when afterEvalOurs > IGNORELOSSLIMIT', () => {
                 const selector = new MoveSelector({
                     CAREABOUTENGINE: 1,
-                    SOUNDNESSLIMIT: -50,
-                    LOSSLIMIT: -30,
-                    IGNORELOSSLIMIT: 300
+                    SOUNDNESSLIMIT: -50, LOSSLIMIT: -30, IGNORELOSSLIMIT: 300
                 });
-
-                // moveLoss 40 > LOSSLIMIT 30, but passes SOUNDNESSLIMIT 50
-                // eval 350 > IGNORELOSSLIMIT 300, so should pass (we're winning big)
-                const analysis = { moveLoss: 40, evaluation: 350 };
-                const result = selector.validateMoveSoundness(
-                    null, 'd2d4', 'e2e4', analysis
-                );
-
-                expect(result).toBe(true);
+                expect(selector.validateMoveSoundness(null, 'd2d4', 'e2e4',
+                    makeAnalysis(350, -40))).toBe(true);
             });
 
-            test('negative eval magnitude is used for IGNORELOSSLIMIT check', () => {
-                // When we're losing badly, absolute value of eval is compared
+            test('large negative eval does NOT trigger IGNORELOSSLIMIT (sign-correct)', () => {
                 const selector = new MoveSelector({
                     CAREABOUTENGINE: 1,
-                    SOUNDNESSLIMIT: -50,
-                    LOSSLIMIT: -30,
-                    IGNORELOSSLIMIT: 300
+                    SOUNDNESSLIMIT: -50, LOSSLIMIT: -30, IGNORELOSSLIMIT: 300
                 });
-
-                // eval -350 has absolute value 350 > 300, so should pass
-                const analysis = { moveLoss: 40, evaluation: -350 };
-                const result = selector.validateMoveSoundness(
-                    null, 'd2d4', 'e2e4', analysis
-                );
-
-                expect(result).toBe(true);
+                expect(selector.validateMoveSoundness(null, 'd2d4', 'e2e4',
+                    makeAnalysis(-350, -40))).toBe(false);
             });
         });
 
@@ -548,70 +515,48 @@ describe('MoveSelector - Step 4: Move Selection Algorithm', () => {
             test('engine best move always passes regardless of config', () => {
                 const strictSelector = new MoveSelector({
                     CAREABOUTENGINE: 1,
-                    SOUNDNESSLIMIT: -10, // Very strict
-                    LOSSLIMIT: -5,
-                    IGNORELOSSLIMIT: 1000
+                    SOUNDNESSLIMIT: -10, LOSSLIMIT: -5, IGNORELOSSLIMIT: 1000
                 });
-
-                // Even with "bad" analysis, if it's the best move, it passes
-                const analysis = { moveLoss: 100, evaluation: -500 };
-                const result = strictSelector.validateMoveSoundness(
-                    null, 'e2e4', 'e2e4', analysis // move === engineBestMove
-                );
-
-                expect(result).toBe(true);
+                expect(strictSelector.validateMoveSoundness(null, 'e2e4', 'e2e4',
+                    makeAnalysis(-500, -100))).toBe(true);
             });
         });
 
         describe('CAREABOUTENGINE=0 bypass', () => {
             test('all moves pass when CAREABOUTENGINE is 0', () => {
                 const noEngineSelector = new MoveSelector({
-                    CAREABOUTENGINE: 0, // Skip engine validation
-                    SOUNDNESSLIMIT: -10,
-                    LOSSLIMIT: -5,
-                    IGNORELOSSLIMIT: 1000
+                    CAREABOUTENGINE: 0,
+                    SOUNDNESSLIMIT: -10, LOSSLIMIT: -5, IGNORELOSSLIMIT: 1000
                 });
-
-                // Even terrible analysis should pass
-                const terribleAnalysis = { moveLoss: 500, evaluation: -1000 };
-                const result = noEngineSelector.validateMoveSoundness(
-                    null, 'd2d4', 'e2e4', terribleAnalysis
-                );
-
-                expect(result).toBe(true);
+                expect(noEngineSelector.validateMoveSoundness(null, 'd2d4', 'e2e4',
+                    makeAnalysis(-1000, -500))).toBe(true);
             });
         });
 
-        describe('Missing analysis handling', () => {
-            test('null analysis treated as zero moveLoss', () => {
+        describe('Missing analysis handling (fail-closed)', () => {
+            test('null analysis rejects when not engine-best', () => {
                 const selector = new MoveSelector({
                     CAREABOUTENGINE: 1,
-                    SOUNDNESSLIMIT: -50,
-                    LOSSLIMIT: -100,
-                    IGNORELOSSLIMIT: 300
+                    SOUNDNESSLIMIT: -50, LOSSLIMIT: -100, IGNORELOSSLIMIT: 300
                 });
-
-                // null analysis means moveLoss defaults to 0
-                const result = selector.validateMoveSoundness(
-                    null, 'd2d4', 'e2e4', null
-                );
-
-                expect(result).toBe(true);
+                expect(selector.validateMoveSoundness(null, 'd2d4', 'e2e4', null)).toBe(false);
             });
 
-            test('undefined analysis treated as zero moveLoss', () => {
+            test('undefined analysis rejects when not engine-best', () => {
                 const selector = new MoveSelector({
                     CAREABOUTENGINE: 1,
-                    SOUNDNESSLIMIT: -50,
-                    LOSSLIMIT: -100,
-                    IGNORELOSSLIMIT: 300
+                    SOUNDNESSLIMIT: -50, LOSSLIMIT: -100, IGNORELOSSLIMIT: 300
                 });
+                expect(selector.validateMoveSoundness(null, 'd2d4', 'e2e4', undefined)).toBe(false);
+            });
 
-                const result = selector.validateMoveSoundness(
-                    null, 'd2d4', 'e2e4', undefined
-                );
-
-                expect(result).toBe(true);
+            test('analysis missing new fields rejects (fail-closed)', () => {
+                const selector = new MoveSelector({
+                    CAREABOUTENGINE: 1,
+                    SOUNDNESSLIMIT: -50, LOSSLIMIT: -100, IGNORELOSSLIMIT: 300
+                });
+                expect(selector.validateMoveSoundness(null, 'd2d4', 'e2e4',
+                    { moveLoss: 10, evaluation: 20 })).toBe(false);
             });
         });
     });

--- a/client/tests/perspective-invariants.test.js
+++ b/client/tests/perspective-invariants.test.js
@@ -57,13 +57,18 @@ class MockEngineWithPerspective {
         }
 
         const isBestMove = move === this.bestMove;
+        const beforeEval = 25;
+        const afterEvalOurs = isBestMove ? 25 : -5;
+        const signedMoveLoss = afterEvalOurs - beforeEval;
         return {
             move,
             bestMove: this.bestMove,
-            evaluation: isBestMove ? 25 : -5,
-            beforeEval: 25,
-            afterEval: isBestMove ? -25 : 5, // Opponent's perspective
-            moveLoss: isBestMove ? 0 : 30,
+            evaluation: -afterEvalOurs,
+            beforeEval,
+            afterEval: -afterEvalOurs,
+            afterEvalOurs,
+            signedMoveLoss,
+            moveLoss: Math.abs(signedMoveLoss),
             isBestMove,
             quality: isBestMove ? 'excellent' : 'good'
         };
@@ -404,21 +409,28 @@ describe('Perspective Invariants', () => {
             expect(analysis.isBestMove).toBe(true);
         });
 
-        test('soundness validation uses absolute value correctly', async () => {
+        test('soundness validation applies SOUNDNESSLIMIT as eval floor', async () => {
             const moveSelector = new MoveSelector({
                 CAREABOUTENGINE: 1,
-                SOUNDNESSLIMIT: -50, // Stored as negative
+                SOUNDNESSLIMIT: -50,
                 LOSSLIMIT: -100,
                 IGNORELOSSLIMIT: 300
             });
 
-            // Test that SOUNDNESSLIMIT comparison works correctly
-            // moveLoss of 30 should pass (30 < 50)
-            const goodAnalysis = { moveLoss: 30, evaluation: 20 };
+            // afterEvalOurs above floor and signedMoveLoss within LOSSLIMIT → pass.
+            const goodAnalysis = {
+                afterEvalOurs: -20,
+                signedMoveLoss: -30,
+                evaluation: 20, afterEval: 20, beforeEval: 10, moveLoss: 30
+            };
             expect(moveSelector.validateMoveSoundness(null, 'd2d4', 'e2e4', goodAnalysis)).toBe(true);
 
-            // moveLoss of 60 should fail (60 > 50)
-            const badAnalysis = { moveLoss: 60, evaluation: 20 };
+            // afterEvalOurs below floor → fail.
+            const badAnalysis = {
+                afterEvalOurs: -80,
+                signedMoveLoss: -60,
+                evaluation: 80, afterEval: 80, beforeEval: -20, moveLoss: 60
+            };
             expect(moveSelector.validateMoveSoundness(null, 'd2d4', 'e2e4', badAnalysis)).toBe(false);
         });
     });

--- a/client/tests/python-parity.test.js
+++ b/client/tests/python-parity.test.js
@@ -1,0 +1,76 @@
+/**
+ * Property test that _passesSoundnessCheck matches the Python reference at
+ * origin/pythonlegacy:workerEngineReduce.py:268 across many random tuples.
+ *
+ * Reference (Python, paraphrased and POV-normalized to our POV):
+ *
+ *   def python_passes(after_eval_ours, signed_move_loss, S, L, I):
+ *       if after_eval_ours > I:
+ *           return True
+ *       if signed_move_loss >= 0:
+ *           return True
+ *       return (after_eval_ours > S) and (signed_move_loss > L)
+ */
+import MoveSelector from '../src/algorithm/MoveSelector.js';
+
+function pythonReference(afterEvalOurs, signedMoveLoss, SOUND, LOSS, IGNORE) {
+    if (afterEvalOurs > IGNORE) return true;
+    if (signedMoveLoss >= 0) return true;
+    return afterEvalOurs > SOUND && signedMoveLoss > LOSS;
+}
+
+// Deterministic seeded RNG (mulberry32).
+function rng(seed) {
+    let t = seed >>> 0;
+    return () => {
+        t += 0x6D2B79F5;
+        let x = t;
+        x = Math.imul(x ^ (x >>> 15), x | 1);
+        x ^= x + Math.imul(x ^ (x >>> 7), x | 61);
+        return ((x ^ (x >>> 14)) >>> 0) / 4294967296;
+    };
+}
+
+describe('JS soundness check ↔ Python reference parity', () => {
+    test('agrees on 1000 seeded random tuples', () => {
+        const rand = rng(0xC0FFEE);
+        const range = (r, min, max) => Math.floor(min + r() * (max - min + 1));
+
+        for (let i = 0; i < 1000; i++) {
+            const afterEvalOurs = range(rand, -800, 800);
+            const signedMoveLoss = range(rand, -800, 200);
+            const SOUND = range(rand, -300, 100);
+            const LOSS = range(rand, -300, 0);
+            const IGNORE = range(rand, 100, 600);
+
+            const selector = new MoveSelector({
+                CAREABOUTENGINE: 1,
+                SOUNDNESSLIMIT: SOUND,
+                LOSSLIMIT: LOSS,
+                IGNORELOSSLIMIT: IGNORE,
+                MINPLAYRATE: 0,
+                MINGAMES: 0,
+                ALPHA: 0.05
+            });
+
+            const analysis = {
+                afterEvalOurs,
+                signedMoveLoss,
+                evaluation: -afterEvalOurs,
+                afterEval: -afterEvalOurs,
+                moveLoss: Math.abs(signedMoveLoss),
+                beforeEval: afterEvalOurs - signedMoveLoss
+            };
+
+            const js = selector._passesSoundnessCheck('d2d4', 'e2e4', analysis);
+            const py = pythonReference(afterEvalOurs, signedMoveLoss, SOUND, LOSS, IGNORE);
+
+            if (js !== py) {
+                throw new Error(
+                    `Disagreement at iter=${i}: afterEvalOurs=${afterEvalOurs}, signedMoveLoss=${signedMoveLoss}, ` +
+                    `SOUND=${SOUND}, LOSS=${LOSS}, IGNORE=${IGNORE} → js=${js}, py=${py}`
+                );
+            }
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Re-port `origin/pythonlegacy:workerEngineReduce.py:268` so Soundness Limit and Move Loss Limit behave as the help text describes (and as the Python original did).
- Engine wrappers now emit `afterEvalOurs` (our POV) and `signedMoveLoss` (signed drop vs engine-best) alongside legacy `evaluation`/`moveLoss` magnitudes.
- `MoveSelector._passesSoundnessCheck` now implements the Python three-branch rule: IGNORELOSSLIMIT escape → `signedMoveLoss >= 0` escape (covers equal-mate-against-us) → both eval-floor and relative-drop gates must pass. **Fails closed** on missing fields.
- Drops `_handleMateScenarios` (already unreachable for real engine output, `MATE_SCORE_THRESHOLD=999999` vs engine `±10000`).
- Removes every `Math.abs(this.config.SOUNDNESSLIMIT|LOSSLIMIT)`.
- UX: revised help text in `app.html` and re-tuned the affected sample-openings presets.

## Behavior change (user-visible)
Repertoires built with default `-99 / -99` previously got effectively no engine filtering due to the sign-inverted comparison. After this lands, those same settings will start rejecting moves whose `signedMoveLoss < -99`. The Move Loss Limit is now the knob to make the algorithm prefer engine-best moves.

## Test plan
- [x] New: `tests/move-selector-semantics.test.js` — table-driven Python-parity cases (incl. ±10000 mate handling, fail-closed)
- [x] New: `tests/engine-perspective-contract.test.js` — pins POV convention on wrapper output
- [x] New: `tests/python-parity.test.js` — 1000-tuple property test vs JS reference of Python `:268`
- [x] New: `tests/danish-gambit-regression.test.js` — end-to-end: `LOSSLIMIT=-10` rejects d4, `-50` admits it
- [x] All existing mocks updated to include new fields; old soundness tests rewired to test new semantics
- [x] `git grep -n "Math.abs(this.config.SOUNDNESSLIMIT\|Math.abs(this.config.LOSSLIMIT)"` → empty
- [x] `git grep -n "_handleMateScenarios"` → empty
- [x] `npm test`: 609 passing. 3 pre-existing ProgressTracker integration failures on `web` baseline are unrelated.
- [ ] Manual browser smoke: `Move Loss Limit = -20`, generate from `1. e4` PGN, confirm Nf3 is chosen.

## Out of scope
- `analyzeMove` depth cap (`Math.min(this.depth, 15)`) — separate issue.
- IGNORELOSSLIMIT JS-only `Math.abs(eval)` symmetry bug — fixed incidentally as part of Step 2a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)